### PR TITLE
docs+test: target architecture, a domain model, and the gate that enforces them

### DIFF
--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -1,0 +1,159 @@
+# Architecture — target and route
+
+Where the code is going, why, and how it gets there without a rewrite.
+The *what* — the concepts this architecture arranges — is in
+[`domain-model.md`](domain-model.md); this document only decides where things
+live and which direction dependencies point.
+
+## The decision that shapes everything: the axis of variation
+
+The obvious way to organise a project that wants to support several car brands is
+an abstract class per brand and a subclass per model. That would be the wrong
+axis here, and the evidence is specific.
+
+**Brands share the machinery.** The servers, the MQTT brokers and the
+certificates all live on one platform's infrastructure. Two of the encryption
+keys are byte-for-byte identical between the OMODA/Jaecoo app and the
+Chery-branded one. A car's badge changes the logo and the marketing name, and
+nothing else.
+
+**What genuinely differs is the front door.** There are (at least) three
+telematics stacks in this family: the OMODA/Jaecoo *legend* gateway that this
+integration speaks, a Chery-branded stack with a different BFF, a separate user
+service and a different request-signing scheme, and CarLinko, which is a
+different protocol altogether — flat REST and WebSockets instead of MQTT. Within
+one stack, moving between deployments has been shown to need nothing but a
+different hostname: the same signing secret, the same client identity and the same
+tenant were accepted unchanged by a second regional gateway. So the abstraction
+that pays for itself sits at **authentication, signing and transport** — not at
+the badge.
+
+**And what a car can do is discovered, not declared by its type.** The backend is
+asked what the vehicle is and adapts; two cars of the same model can be refused
+different commands, and the same car can accept a command in the morning and
+refuse it at night. A `class Omoda9` cannot represent a capability that changed at
+23:18.
+
+Hence: **platform is the abstraction, region and brand are data, model is a set of
+capabilities discovered at runtime.**
+
+## Target layout
+
+```
+custom_components/<domain>/
+├── platform/          # the abstract seam: how we authenticate, sign, and reach a stack
+│   ├── base.py            protocol: log in, refresh, sign, send, subscribe
+│   ├── legend.py          OMODA/Jaecoo gateway — the implemented one
+│   └── regions.py         host, tenant, certificate bundle: pure data
+├── transport/         # the pipes, and nothing else
+│   ├── mqtt.py            the broker client, mTLS, subscriptions
+│   └── http.py            signed request/response
+├── domain/            # the model in domain-model.md, in code. No HA, no network.
+│   ├── vehicle.py         identity, telemetry state, invariants
+│   ├── capabilities.py    discovery, validation, "unknown is not false"
+│   ├── commands.py        catalog, TaskId lifecycle, result classification, retry policy
+│   └── access.py          login id, OTP channel, PIN lockout
+├── features/          # the services built on the domain
+│   ├── energy.py          charge sessions, home/away attribution
+│   └── comfort.py         the climate/seats macro
+├── brands/            # display name, logo, imagery: data
+├── coordinator.py     # orchestration only: schedule, fan out, hold state
+└── <platform>.py      # the Home Assistant entity modules
+```
+
+Dependencies point one way, and each arrow is enforced by a test (see
+[The ratchet](#the-ratchet)):
+
+```
+entity modules  →  features/  →  domain/  →  platform/  →  transport/
+                        └──────────────────────→ domain/
+```
+
+`domain/` imports neither Home Assistant nor the network — that is what makes it
+testable in isolation, and it is already true of today's `core/`.
+
+## Where things live today, and where they go
+
+Most of this is **re-seating, not rewriting**. A large part of the target already
+exists as well-written modules sitting in the wrong place.
+
+| Today | Goes to | Note |
+|---|---|---|
+| `coordinator.py` (~1850 lines) | split across `transport/mqtt.py`, `features/`, `domain/`, and a much smaller `coordinator.py` | the only genuinely new seam |
+| `core/session.py`, `login_omoda.py`, `omoda_auth.py`, `prova_token.py`, `provision.py`, `captcha_solver.py`, `tsp_sign.py` | `platform/legend.py` | the front door, already isolated from HA |
+| `core/tls_client.py` | `transport/http.py` | the client whose TLS fingerprint clears the SMS route |
+| `cert_bundle.py`, `certs/store.json` | `platform/regions.py` | already data; make it only data |
+| `core/commands.py`, `core/codes.py`, `core/routing.py` | `domain/commands.py` | the catalog and the result classification |
+| `capabilities_from_item()` in `const.py` | `domain/capabilities.py` | the seed of the capability model |
+| `core/permessi.py` (v1.11.0–v1.13.0) | `domain/capabilities.py` | per-vehicle authorisation: already HA-free, already keyed by endpoint rather than by feature name |
+| `core/pin_lockout.py` | `domain/access.py` | already an encapsulated invariant |
+| `core/mask.py`, `core/context.py`, `timers.py`, `diag.py` | cross-cutting, stay | infrastructure, not domain |
+| the charged-energy integrators inside `coordinator.py` | `features/energy.py` | |
+| `brand/` | `brands/` | presentation data |
+| `sensor.py`, `switch.py`, `climate.py`, … | unchanged in place | they only lose their one shortcut into `core/` |
+
+## A deliberate deviation, and why
+
+The engineering standard this project follows requires the domain model to be
+written **before** the layer code. That rule is written for a project that is
+starting; this one is not. It already runs on other people's cars, and a
+"model first, then rewrite" reading would mean a big-bang migration with a live
+install base as the test group.
+
+The brownfield reading of the same rule, and the one adopted here: **the domain
+model is still written first, and it binds all future code**. Existing code
+converges on it slice by slice, each slice releasable on its own. What makes this
+honest rather than an excuse is that convergence is mechanically enforced —
+see below. The gap between model and code is not left to memory: it is listed in
+[`domain-model.md`](domain-model.md#known-gaps) and in the slice table.
+
+## The ratchet
+
+`tests/test_architecture.py` runs in CI alongside the test suite. Its contract is
+one-way:
+
+1. it starts with only the rules the code **already satisfies**, so the baseline
+   is green and costs nothing;
+2. each slice adds **one** assertion, in the same commit that makes it true;
+3. no rule is ever weakened or removed to make a change pass.
+
+Architecture is not maintained by remembering it in review. It is maintained by a
+test that blocks the merge.
+
+Rules live today (all passing): `core/` is free of Home Assistant imports; entity
+modules never import the network; `core/` never imports entity modules; `const.py`
+is a leaf.
+
+## The route
+
+Each slice is independently releasable, and lands one new rule.
+
+| # | Slice | New rule it locks | Why here |
+|---|---|---|---|
+| 0 | This document, the domain model, the baseline test | the four rules above | costs nothing, sets the target |
+| 1 | `transport/mqtt.py` — lift the broker client out of the coordinator | `paho` may only be imported from `transport/` | the sharpest cut, and the existing fake-cloud fixture makes it genuinely testable |
+| 2 | `platform/legend.py` + `platform/regions.py` | `requests`/`ssl`/`socket` only in `platform/` and `transport/` | creates the seam a second stack would plug into |
+| 3 | `domain/` — capabilities, commands, access | `domain/` imports neither HA nor the network | the invariants in the domain model get a home, and the retry policy lands where it belongs |
+| 4 | `features/energy.py`, `features/comfort.py` | entity modules import only `features/` and `domain/` | the cards stop asking "which car is this" and start asking "what can it do" |
+| 5 | the coordinator becomes orchestration | a size ceiling on `coordinator.py` | the result, not the goal |
+
+Two consequences worth stating, because they change the order of unrelated work:
+
+- The **retry policy for transient command rejections** belongs to
+  `domain/commands.py`, i.e. slice 3. It is also a bug that bites today, so it
+  ships tactically in the consolidation and is re-homed in slice 3 rather than
+  waiting for it.
+- The **capability model is what makes the dashboard cards portable**. Once a card
+  can ask what a vehicle supports instead of which model it is, the same card
+  works on every car in the family — and the compatibility matrix everyone has
+  asked for becomes a report over the same data, not a separate hand-kept table.
+
+## Out of scope
+
+- Rewriting behaviour. Slices move code and lock rules; they do not change what
+  the integration does. A slice that also changes behaviour is two commits.
+- Implementing the other platforms. `platform/base.py` exists so that a second
+  stack *can* be added by whoever reverses it; adding it is not part of this route.
+- The Home Assistant domain rename. It is a user-visible migration with its own
+  release and its own communication, and it is deliberately not bundled with any
+  slice here.

--- a/docs/design/domain-model.md
+++ b/docs/design/domain-model.md
@@ -1,0 +1,227 @@
+# Domain model
+
+This document defines **what** the integration talks about, before any decision
+about how the code is arranged. It is the single source of truth for the domain:
+the code implements it, it is not an alternative description of it. The layer
+layout that implements this model lives in [`architecture.md`](architecture.md).
+
+It is written for a codebase that already exists and already runs on other
+people's cars. Where today's code contradicts the model, that is recorded
+honestly in [Known gaps](#known-gaps) rather than quietly smoothed over — a
+documented gap is a work item, an undocumented one is a bug waiting to be
+rediscovered.
+
+## Why this model looks the way it does
+
+Three findings from the field shaped it, and they are worth stating up front
+because they explain choices that would otherwise look arbitrary.
+
+The first is that **the vehicle is not the unit of variation**. Two cars of the
+same model, on the same firmware, do not necessarily accept the same commands,
+and the same car does not necessarily accept the same command twice: a comfort
+macro that succeeded four times in one day started being refused later the same
+evening. Anything the model says about "what a car can do" is therefore a
+statement about *what the backend declared, when we last asked* — never a
+property baked into a type.
+
+The second is that **the brand is not the unit of variation either**. Servers,
+MQTT brokers and certificates all live on one platform; the pieces that actually
+differ between deployments are the authentication front door and a handful of
+host/tenant values. A car's badge is presentation.
+
+The third is that **acceptance is not execution**. The backend answering "issued
+successfully" and the car actually doing the thing are two different events,
+arriving over two different channels, and a domain that collapses them lies to
+the user.
+
+## Glossary — ubiquitous language
+
+These names are the same in this document, in the code, and in the user-facing
+strings. No layer renames a concept on the way through.
+
+| Term | Meaning | Not to be used as a synonym |
+|---|---|---|
+| **Vehicle** | One car bound to one account, the aggregate root of everything we know about it | "device" (that is a Home Assistant object), "car id" |
+| **VIN** | The vehicle's identity, everywhere and always | "vehicle number", "chassis" |
+| **Platform** | The auth + signing + transport front door of a telematics stack (e.g. the OMODA/Jaecoo *legend* gateway, the Chery-branded BFF/UAA stack, CarLinko). Determines *how* we authenticate and speak | "brand", "region" |
+| **Region** | One deployment of a platform: BFF host, tenant, certificate bundle. Data, not behaviour | "country", "market" |
+| **Brand** | Marketing identity: display name, logo, imagery. Presentation only, never behaviour | "platform", "model" |
+| **Model** | What the car calls itself. Used for display and for the compatibility matrix — never as a branching condition in code | "variant", "trim" |
+| **Capability** | Something a *specific* vehicle declared it can do or accept, as reported by the backend at a point in time | "feature", "option" |
+| **Command** | An intent addressed to a vehicle (lock, climate on, seat heating…) | "action", "service call" |
+| **Command catalog** | The single shared set of commands the platform exposes; vehicles differ by which ones they accept, not by which exist | — |
+| **TaskId** | Short-lived control credential minted by `checkPassword`, scoped to a session and **not** to a command category | "token" (that is a login credential) |
+| **Control PIN** | The 4-digit code that signs commands. It is **not** a login credential | "password", "PIN di accesso" |
+| **Backend acceptance** | The synchronous answer to the HTTP call (`A00079` accepted, `A00084` denied…) | "result", "confirmation" |
+| **Vehicle acknowledgement** | The asynchronous confirmation the car later publishes over MQTT, carrying `result` and an optional `reason` list | "response", "ack HTTP" |
+| **Telemetry frame** | One coherent set of vehicle readings as published by the car | "update", "poll" |
+| **Placeholder frame** | A frame whose fields are structurally impossible (high-voltage readings at `0`/`-1000`, an odometer that went backwards). Carries no information and must never be treated as a reading | "stale data", "glitch" |
+| **Charge session** | One continuous period during which the vehicle reports charging | "charge", "cycle" |
+| **Zone** | Whether the vehicle is at the user's home location or away. Decides how charged energy is attributed | "location" (that is a coordinate) |
+| **Poll cycle** | Periodic sampling of the vehicle, gated by the user-facing *Auto Update* switch | "refresh" |
+| **Settle** | The minimum quiet interval enforced after a command, before another may be sent | "delay", "timeout" |
+
+## Entities and aggregates
+
+### `Vehicle` — aggregate root
+
+- **Identity:** the VIN. Everything else about a vehicle, including its name, is
+  mutable decoration.
+- **Attributes:** identity (name, model, brand), a `CapabilitySet`, the last known
+  `TelemetrySnapshot`, the current `ChargeSession` if any, current `Zone`.
+- **Aggregate boundary:** capabilities, telemetry and charge sessions have no
+  meaning outside a vehicle and are only reachable through it. Commands are
+  addressed *to* a vehicle but have their own lifecycle (see below).
+- **Invariants:**
+  - **The odometer never decreases.** A frame reporting a lower odometer than the
+    last known value is a placeholder frame, not a reading.
+  - **A placeholder frame never overwrites a good value.** The previous reading
+    survives; the entity reports its last known state rather than a fiction.
+  - **Identity is never silently overwritten.** A probe performed to learn
+    capabilities must not rewrite a name the user chose, or one already cached.
+  - **State of charge does not fall during a charge session.** A drop back to the
+    session's starting value at charge completion is a placeholder frame.
+
+### `CapabilitySet` — what this vehicle declared, and when
+
+- **Identity:** none of its own; it belongs to its `Vehicle`.
+- **Attributes:** the declared values (power type, climate temperature range, …),
+  plus a marker recording that a probe has actually happened.
+- **Invariants:**
+  - **Absence is not negation.** A capability the backend did not declare is
+    *unknown*, and unknown must fall back to the historical behaviour. Suppressing
+    a feature requires a positive declaration: fuel sensors disappear only for a
+    *confirmed* battery-electric vehicle, never for an undeclared one.
+  - **Implausible declarations are discarded, not adopted.** A climate range
+    outside human plausibility is bad data, not an exotic car; the defaults hold.
+  - **"Never asked" is distinguishable from "asked, backend said nothing".**
+    Without that distinction a silent backend causes an identical probe on every
+    restart.
+  - **Capabilities may change over time** and must be re-probeable. They are a
+    cache with a reason to expire, not a constant.
+
+### `Command` — an intent with two answers
+
+- **Identity:** the request sequence (VIN + timestamp) together with the `TaskId`
+  under which it was issued.
+- **Attributes:** the catalog entry, its parameters, the backend acceptance, and
+  — when it arrives — the vehicle acknowledgement.
+- **Invariants:**
+  - **At most one command is in flight per vehicle.** This is not an
+    implementation detail of our client: the backend enforces it and rejects the
+    second one. Serialisation plus a settle interval is therefore part of the
+    domain, not an optimisation.
+  - **Acceptance is not execution.** A command with backend acceptance and no
+    vehicle acknowledgement has not been carried out, and must not be reported as
+    success.
+  - **A retryable rejection is retried before the user sees it.** "Another
+    instruction is being issued" is a transient collision, not a failure; only a
+    terminal outcome reaches the user.
+  - **A refused control PIN is never reported as success.**
+  - **A `TaskId` is per session, not per command category.** One valid `TaskId`
+    drives every category; a category-specific denial is a permission decision by
+    the backend, and no re-minting will change it.
+
+### `Access` — the account and its credentials
+
+- **Identity:** the account (login id).
+- **Attributes:** login id (email or phone), the OTP channel that was used, the
+  issued tokens, the control PIN and its lockout counter.
+- **Invariants:**
+  - **The OTP channel is stable for a given login.** A login that started as
+    email stays email on re-authentication; a phone login carries its number.
+  - **The control PIN is not a login credential.** Losing it must never invalidate
+    a session; a wrong one must never look like an authentication problem.
+  - **After repeated wrong PIN attempts the client refuses locally**, rather than
+    letting the backend lock the account out.
+  - **Secrets never travel through process arguments.**
+
+### `ChargeSession` — energy, and what we can honestly claim about it
+
+- **Identity:** the vehicle plus the session start.
+- **Attributes:** start and end, the zone it took place in, accrued energy.
+- **Invariants:**
+  - **Energy accrues only while the vehicle reports charging.** Charging power
+    read outside that state is noise, not a measurement.
+  - **An unobserved interval is recorded as unobserved.** When consecutive samples
+    are further apart than the trust threshold, that stretch of the session is
+    unaccounted for — the session must carry that fact rather than silently
+    reporting a smaller number as if it were complete.
+  - **Accrued energy is battery-side, not meter-side.** It is what went into the
+    battery, not what the wall socket delivered, and must never be presented as
+    the quantity that was paid for.
+
+## Value objects
+
+| Value object | Composition | Constraints |
+|---|---|---|
+| `Vin` | the 17-character identifier | opaque, never parsed for meaning |
+| `Region` | BFF host, tenant, certificate bundle | a region is fully described by data; adding one must never require code |
+| `Brand` | display name, logo, imagery | presentation only; no behaviour may branch on it |
+| `TemperatureRange` | minimum, maximum, step | minimum < maximum, both within human plausibility; step from the allowed set; an out-of-range declaration is discarded |
+| `ResultCode` | the backend code plus its classification: accepted, transient, permission, parameter, session | the classification is the domain's, and every code maps to exactly one class |
+| `LoginId` | the identifier plus its channel (email or phone) | the channel is derived from the identifier's form, once, and then carried |
+| `Zone` | home or away | derived from position and the configured home location |
+
+## Relations
+
+- `Vehicle` **1 — 1** `CapabilitySet`, `Zone`, latest `TelemetrySnapshot`.
+- `Vehicle` **1 — 0..\*** `ChargeSession`; at most one open at a time.
+- `Vehicle` **1 — 0..\*** `Command`; at most one in flight at a time.
+- `Access` **1 — 1..\*** `Vehicle`; a vehicle is reachable only through its account.
+- `Region` **\* — 1** `Platform`; a platform has many regions, a region belongs to one.
+- `Brand` is attached to a `Vehicle` for display and has no relation to `Platform`.
+
+## Bounded contexts
+
+Four contexts, each with its own model, meeting at explicit points:
+
+- **Access** — captcha, one-time codes, tokens, control PIN, lockout. Knows
+  nothing about vehicles beyond which ones an account may reach.
+- **Control** — the command catalog, `TaskId` lifecycle, result classification.
+  Owns the "at most one in flight" rule.
+- **Telemetry** — frames, placeholder detection, the last-known-good state. Owns
+  the odometer and placeholder invariants.
+- **Energy** — charge sessions, zone attribution, observability of an interval.
+  Consumes Telemetry, never reads the network itself.
+
+**Control and Telemetry meet at the acknowledgement.** A command's outcome is
+completed by a frame that arrives through the telemetry channel; that crossing is
+the one place where the two models translate into each other, and it is where the
+"acceptance is not execution" rule is enforced.
+
+## Known gaps
+
+Where the code does not yet uphold the model. Each is a work item, not a
+tolerated exception.
+
+| Invariant | Current behaviour | Consequence observed |
+|---|---|---|
+| The odometer never decreases | Frames are taken at face value | An odometer went backwards at charge completion; range and state of charge collapsed in the same frame |
+| A retryable rejection is retried before the user sees it | Rejections are classified as retryable, but nothing consumes the classification | The transient "another instruction is being issued" reaches the user as a red error |
+| An unobserved interval is recorded as unobserved | Intervals beyond the trust threshold are silently skipped | A slow charge was reported as a fraction of the energy actually stored, with nothing indicating the number was partial |
+| Capabilities are re-probeable | Probed once, with no expiry path | A vehicle whose declarations change keeps the old ones until reconfigured |
+
+---
+
+*Maintenance: changing an entity or an invariant is a change **to this document**,
+not only to the code. An undocumented invariant is a debt.*
+
+## Note — what v1.10.0–v1.13.0 already confirmed
+
+This model was drafted against v1.10.0 and is published against v1.13.0. The work that
+landed in between is evidence for it rather than against it, and it is worth recording
+which parts are no longer hypothetical:
+
+- **Capabilities are discovered, not declared by model name.** `capabilities_from_item()`
+  and `core/permessi.py` decide what a *specific* vehicle accepts from what the backend
+  answers for that vehicle — which is the axis this model claims is the real one.
+- **Absence is not negation.** `permessi.py` keeps an explicit sentinel for "I tried to
+  read the permissions and failed", distinct from "I have not asked yet", and in both
+  cases sends the command as before. That is exactly the invariant stated below, already
+  implemented.
+- **The unit of authorisation is the endpoint, not the feature name.** The tailgate appears
+  both as `2032` (denied) and under category `205` (allowed); keying by feature name would
+  have produced the wrong answer.
+
+The seam this model asks for is therefore mostly *where these pieces live*, not what they do.

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -1,0 +1,182 @@
+"""Architectural gate — a ratchet, not a checklist.
+
+Every rule in this file was true when it was added, and must stay true forever.
+The contract is deliberately one-way:
+
+  * a rule enters this file in the *same commit* that makes it true;
+  * a rule is never weakened or removed to make a change pass.
+
+That is what lets an existing codebase converge on the target architecture
+described in ``docs/design/architecture.md`` without a big-bang rewrite: each
+extraction slice lands with one new assertion, and CI stops the code from
+drifting back.
+
+Rules that are NOT here yet, and the slice that will add them (see
+``docs/design/architecture.md`` for the full plan):
+
+  slice 1  ``paho`` may only be imported from ``transport/``
+           (today: __init__.py, coordinator.py, diag.py)
+  slice 2  ``requests``/``ssl``/``socket`` may only be imported from
+           ``platform/`` and ``transport/``
+           (today: coordinator.py, config_flow.py and six ``core/`` modules)
+  slice 3  ``domain/`` may not import Home Assistant nor the network
+  slice 4  entity platforms may only import ``features/`` and ``domain/``
+           (today: button.py reaches into ``core.commands``)
+
+The checks are static: the file is parsed, never imported, so this suite runs
+without Home Assistant installed — the same constraint the rest of the suite
+already lives under.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _component_dir() -> Path:
+    """The integration package, found by shape rather than by name.
+
+    The domain is going to be renamed; hard-coding it here would turn a rename
+    into a red build for the wrong reason.
+    """
+    candidates = [
+        p
+        for p in (REPO_ROOT / "custom_components").iterdir()
+        if p.is_dir() and (p / "manifest.json").exists()
+    ]
+    assert len(candidates) == 1, f"expected exactly one integration, found {candidates}"
+    return candidates[0]
+
+
+COMPONENT = _component_dir()
+CORE = COMPONENT / "core"
+
+# The Home Assistant-facing modules: one per platform HA knows about. These are
+# the only files allowed to speak HA's entity language, and the last place that
+# should ever open a socket.
+ENTITY_PLATFORMS = (
+    "binary_sensor.py",
+    "button.py",
+    "climate.py",
+    "cover.py",
+    "device_tracker.py",
+    "lock.py",
+    "number.py",
+    "select.py",
+    "sensor.py",
+    "switch.py",
+    "text.py",
+    "time.py",
+)
+
+NETWORK_ROOTS = {"paho", "requests", "ssl", "socket", "urllib", "http"}
+
+
+def _imported_roots(path: Path) -> set[str]:
+    """Top-level module names imported by ``path``, function-local ones included.
+
+    Deferred imports inside a function are still imports: they are exactly how
+    layering violations hide from a grep, so the AST walk covers the whole tree.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                roots.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:  # relative import — recorded separately below
+                continue
+            if node.module:
+                roots.add(node.module.split(".")[0])
+    return roots
+
+
+def _relative_targets(path: Path) -> set[str]:
+    """First component of every relative import in ``path`` (``from .x import y``)."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    targets: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.level and node.module:
+            targets.add(node.module.split(".")[0])
+    return targets
+
+
+def _core_modules() -> list[Path]:
+    return sorted(CORE.rglob("*.py"))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Rule 1 — core/ is Home Assistant-free.
+#
+# This is the rule the whole test suite rests on: `core/` can be exercised
+# without Home Assistant installed. It is also what makes the protocol logic
+# reusable across platforms (see docs/design/architecture.md).
+# ─────────────────────────────────────────────────────────────────────────────
+def test_core_does_not_import_home_assistant() -> None:
+    offenders = [
+        p.relative_to(REPO_ROOT).as_posix()
+        for p in _core_modules()
+        if "homeassistant" in _imported_roots(p)
+    ]
+    assert not offenders, (
+        "core/ must stay free of Home Assistant imports so it can be tested and "
+        f"reused outside HA; offending files: {offenders}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Rule 2 — entity platforms never talk to the network directly.
+#
+# An entity module renders state and forwards intent. The moment one of them
+# opens its own connection, the transport stops being swappable and the vehicle
+# state has two sources of truth.
+# ─────────────────────────────────────────────────────────────────────────────
+def test_entity_platforms_do_not_touch_the_network() -> None:
+    offenders: dict[str, set[str]] = {}
+    for name in ENTITY_PLATFORMS:
+        path = COMPONENT / name
+        if not path.exists():
+            continue  # platforms differ per line; absence is not a violation
+        leaked = _imported_roots(path) & NETWORK_ROOTS
+        if leaked:
+            offenders[name] = leaked
+    assert not offenders, (
+        "entity platforms must go through the coordinator, never the network: "
+        f"{offenders}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Rule 3 — core/ does not import the entity platforms.
+#
+# Dependencies point one way: HA-facing code may lean on the protocol code, and
+# never the reverse. Without this, `core/` silently becomes un-testable again.
+# ─────────────────────────────────────────────────────────────────────────────
+def test_core_does_not_import_entity_platforms() -> None:
+    platform_names = {name[: -len(".py")] for name in ENTITY_PLATFORMS}
+    offenders: dict[str, set[str]] = {}
+    for path in _core_modules():
+        leaked = _relative_targets(path) & platform_names
+        if leaked:
+            offenders[path.relative_to(REPO_ROOT).as_posix()] = leaked
+    assert not offenders, f"core/ must not depend on HA entity modules: {offenders}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Rule 4 — const.py stays a leaf.
+#
+# Constants and the small pure helpers beside them are imported by everything;
+# the moment const.py imports back into the component, every import becomes a
+# potential cycle.
+# ─────────────────────────────────────────────────────────────────────────────
+def test_const_is_a_leaf_module() -> None:
+    const = COMPONENT / "const.py"
+    assert const.exists(), "const.py is expected at the component root"
+    assert not _relative_targets(const), (
+        "const.py must not import other modules of the component — it is a leaf "
+        f"imported by all of them; found: {_relative_targets(const)}"
+    )


### PR DESCRIPTION
This adds two documents and one test file. **It moves no code and changes no behaviour** — `custom_components/` is untouched, and the four assertions it adds already pass on `master` as it stands today.

### What's in it

- **`docs/design/domain-model.md`** — the vocabulary and the invariants: what a *capability*, a *placeholder frame*, a *backend acceptance* actually are, and rules like *absence is not negation* (a capability the backend didn't declare is not a capability it denied). Most of these are already implemented; this writes them down so they stop being folklore.
- **`docs/design/architecture.md`** — where each existing module goes, and a route in **five independently releasable slices**. Mostly re-seating, not rewriting: a large part of the target already exists as well-written modules sitting in the wrong place.
- **`tests/test_architecture.py`** — four assertions, currently green:
  1. `core/` does not import Home Assistant;
  2. entity platforms do not touch the network;
  3. `core/` does not import entity modules;
  4. `const.py` is a leaf module.

### How the gate is meant to work

It's a **ratchet, not a checklist**. It starts with only the rules that are *already* true, so it can never block anyone today. Each slice adds one assertion **in the same commit that makes it true**, and no assertion is ever removed. That's the whole mechanism: the architecture can't quietly drift back, and nobody has to remember to enforce it.

### Why now

`master` is ~11,360 lines of runtime Python across 40 files, with `coordinator.py` at ~1,850, plus 7,617 lines of tests — reached in a couple of months, and none of us wrote it by hand. Across the last eleven functional changes, a single behavioural change touched between 3 and 16 files (median 5). That's what makes review unaffordable, and review is the only thing that keeps a codebase understandable by more than one person.

The document is written as a table of **invariant / current behaviour / observed symptom**, and that turns out to be the most useful part of it: **the four bugs we can't close are four violations of the same kind.** The odometer that goes backwards at charge completion (nothing enforces "the odometer never decreases", so an impossible frame is taken at face value); `A00082` reaching the user as a red error (rejections *are* classified as retryable, but nothing consumes the classification); the slow charge reported as a fraction of the energy actually stored (an unobserved interval is skipped silently rather than recorded as unobserved); and capabilities that never expire once probed. None of these is a coding mistake — in each case the invariant simply has nowhere to live, so every new frame or command path is free to violate it again. That's what a `domain/` layer is *for*, and it's why I'd rather agree on the model before fixing them one at a time.

The same cut also opens the project up. Segmenting **by platform** — the auth/signing front door (legend gateway vs the Chery BFF+UAA stack vs CarLinko), with brand and region as data and model as discovered capabilities — is what turns "support another Chery model" into data plus capability discovery rather than new code paths. The per-vehicle permission work in v1.11.0–v1.13.0 already runs on exactly that axis; the docs note where it lands (`core/permessi.py` → `domain/capabilities.py`).

### What I'm asking for

Read the two documents, not the test file. **"This is over-engineered" is a legitimate verdict** and I'd rather hear it now than after three slices. If nobody disagrees, slice 1 follows as its own PR.

I'm opening this as a pull request rather than pushing it, deliberately — it's the same thing I'm asking for on the main thread, and it would be odd to ask for it while pushing to `master` myself.
