### PR TITLE
process: how a change lands, and how we say what we tested

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,72 @@
+name: Bug report
+description: Something the integration does wrong, or stopped doing
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before anything else: **remove your VIN, tokens, certificates and account
+        id** from anything you paste. They appear in logs more often than you
+        would expect. `<redacted>` is a perfectly good value.
+
+  - type: dropdown
+    id: model
+    attributes:
+      label: Car
+      description: What this was observed on. It decides who can reproduce it.
+      options:
+        - Omoda 9
+        - Omoda 5 / E5
+        - Omoda 7
+        - Jaecoo 7
+        - Jaecoo 5 / J5
+        - Other Chery-platform car (say which below)
+    validations:
+      required: true
+
+  - type: input
+    id: region
+    attributes:
+      label: Country / region
+      placeholder: IT, UK, DK, …
+    validations:
+      required: true
+
+  - type: input
+    id: versions
+    attributes:
+      label: Integration and Home Assistant versions
+      placeholder: "integration v1.13.0, HA 2026.7.1"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What you expected, and what happened
+      description: |
+        Times help more than anything else — wall-clock, to the second, for what
+        you sent and for what you saw.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: official_app
+    attributes:
+      label: Does the official app manage it?
+      description: >
+        This separates "the car cannot" from "we ask wrongly", and it is usually
+        the fastest thing in the whole report.
+      options:
+        - "Yes — the official app does it fine"
+        - "No — the official app fails too"
+        - "Not tested"
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs (redacted)
+      description: Debug logs for the integration, with identifiers removed.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: How this project works
+    url: https://github.com/chery-connect-ha/omoda9-ha/blob/master/CONTRIBUTING.md
+    about: Roles, how a change lands, and why field tests gate the stable release.
+  - name: How to run a field test
+    url: https://github.com/chery-connect-ha/omoda9-ha/blob/master/docs/field-test.md
+    about: You own one of these cars and want to help without writing code.

--- a/.github/ISSUE_TEMPLATE/field_test.yml
+++ b/.github/ISSUE_TEMPLATE/field_test.yml
@@ -1,0 +1,65 @@
+name: Field test report
+description: You ran a release or a pull request on your own car — tell us what the car did
+labels: ["field-test"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This is the most valuable thing you can contribute, and it needs no code.
+        The method — and why "the backend accepted" is not a result — is in
+        [`docs/field-test.md`](../blob/master/docs/field-test.md).
+
+        **Redact VIN, tokens, certificates and account id before posting.**
+
+  - type: input
+    id: what_tested
+    attributes:
+      label: What you tested
+      placeholder: "v1.13.0 pre-release, or PR #24"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: model
+    attributes:
+      label: Car
+      options:
+        - Omoda 9
+        - Omoda 5 / E5
+        - Omoda 7
+        - Jaecoo 7
+        - Jaecoo 5 / J5
+        - Other Chery-platform car (say which below)
+    validations:
+      required: true
+
+  - type: input
+    id: region
+    attributes:
+      label: Country / region
+      placeholder: IT, UK, DK, …
+    validations:
+      required: true
+
+  - type: textarea
+    id: result
+    attributes:
+      label: What you predicted, sent, and observed
+      description: >
+        The state field that changed, and the times. A command counts as verified
+        only when the car acted — not when the request was accepted.
+      value: |
+        Prediction (written before pressing anything):
+        Sent:
+        Observed:
+        State field:
+    validations:
+      required: true
+
+  - type: textarea
+    id: not_tested
+    attributes:
+      label: What you could not test
+      description: >
+        Part of the result. "My car does not have that" and "I did not get to it"
+        are different, and both are useful.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+## What changes, and why
+
+<!-- One behaviour per pull request. If this touches many files to do one thing,
+     say so — that is information about the architecture, not about you. -->
+
+Closes #
+
+## Evidence
+
+Fill in the row that applies and delete the others. Being honest here costs
+nothing; overstating it is the only mistake in this project that reaches a
+stranger's car.
+
+- [ ] **Verified on hardware** — I own this car and I watched it act.
+      Car / region / version:
+      Sent at:                          Observed at:
+      State field that changed:
+      <!-- The protocol, and why the backend answering OK is not enough:
+           docs/field-test.md -->
+
+- [ ] **Backend only** — the request was accepted, I did not confirm the car
+      acted. Say what stopped you.
+
+- [ ] **Not testable by me** — written for a model I do not own. This is fine;
+      add the `unverified-hardware` label and, if you know who has that car,
+      `needs-field-test:<model>`.
+
+- [ ] **No runtime behaviour** — docs, tests, CI, refactor with no user-visible
+      change.
+
+## Checks
+
+- [ ] Suite green (`pytest tests/ -q`, or CI if the local Python is older than 3.13)
+- [ ] Entity count unchanged, or the change is deliberate and named above
+- [ ] No VIN, token, certificate, account id or raw capture anywhere in the diff
+- [ ] Fails open: nothing here can take away a function that worked for somebody
+- [ ] Design docs updated if this contradicts them

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,8 @@
+The instructions for this repository are in [`AGENTS.md`](../AGENTS.md) at the
+repository root, with the reasoning behind them in
+[`CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+Read `AGENTS.md` before making any change. It carries the invariants that must
+not break (fail open, no secrets, no model names as code paths), the discipline
+about not overstating what has been tested on real hardware, and the exact git
+and GitHub commands for landing a change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,226 @@
+# AGENTS.md — read this before you touch anything
+
+You are probably a coding agent, working for someone who owns one of these cars
+and does not necessarily read code or use GitHub. That is normal here: everyone
+who built this integration built it this way. Your job is to make your human's
+contribution land correctly **without them having to learn git**, and to stop
+them from making the one mistake that actually hurts other people — claiming that
+something works when nobody watched it work.
+
+Read [`CONTRIBUTING.md`](CONTRIBUTING.md) for the reasoning. This file is the
+operational half: what must never break, and the exact commands.
+
+*(Human reading this: you don't need to understand any of it. Point your agent
+here and carry on.)*
+
+## What this project is
+
+A Home Assistant integration for cars on the **Chery telematics platform** —
+OMODA, Jaecoo and their siblings. It is unofficial and reverse-engineered. The
+badge on the car is presentation; what actually varies is the authentication and
+signing front door, the hostname of the region, and the set of commands a given
+vehicle turns out to accept.
+
+Where the truth lives, in order of authority:
+
+1. `docs/design/domain-model.md` — what the integration talks about. The code
+   implements it; it is not a description of the code. *(Proposed in #6.)*
+2. `docs/design/architecture.md` — where things live and which way dependencies
+   point. *(Proposed in #6.)*
+3. `tests/` — what is actually guaranteed. `tests/test_entity_count.py` already
+   enforces that no refactor quietly costs a user an entity;
+   `tests/test_architecture.py` enforces the layering *(proposed in #6)*.
+
+If your change contradicts one of these, the document wins, or the document
+changes in the same pull request. Never leave them disagreeing in silence.
+
+## Invariants — do not break these, ever
+
+**Fail open.** If something cannot be read, is unrecognised, or times out, send
+exactly what we sent before: full request, historic endpoint. The worst an
+untested path may do is *fail to help*. It must never take away a function from
+someone for whom it worked.
+
+**Never remove or narrow a working entity or command** as a side effect of a
+refactor. If the entity count changes, that is a deliberate, announced change —
+and the test will stop you first.
+
+**No Home Assistant imports in `core/`.** The protocol logic must be exercisable
+without Home Assistant installed. This is what lets the sandbox test a change
+without an instance, and it is the rule the whole suite rests on.
+
+**Entity modules never open sockets.** They render state and forward intent.
+
+**No secrets, ever, in this repository.** No VIN, token, certificate, user id,
+account identifier, or raw traffic capture — not in code, not in tests, not in a
+log paste inside an issue. They appear in captured material far more often than
+people expect. Redact before you paste. Fixture data is synthetic.
+
+**No model names as code paths.** A new car is data plus capabilities discovered
+at runtime — not a new branch, class, or `if model == …`. If you find yourself
+adding one, you have found an architecture problem: say so instead of encoding it.
+
+**The suite stays green.** Not "green after a follow-up" — green in the pull
+request that changes the behaviour.
+
+## The discipline that matters most: don't overstate evidence
+
+Half of this codebase is written for cars the author does not own. That is
+unavoidable and it is fine — as long as it is labelled.
+
+Before you write that something works, in a commit message, a pull request, a
+changelog or a release note, ask your human **one question**:
+
+> Did you watch the car do it, or did the backend answer OK?
+
+They are different claims. The backend returning `operation.successful` means the
+request was accepted; it does not mean the vehicle acted. A command has been
+verified only when a state field on the car changed, at a time you can point to.
+
+- If the human owns the car and watched it: say so, and say when.
+- If the human owns the car and only saw the backend accept: say *that*, in those
+  words.
+- If the human does **not** own that model: write the code, open the pull request,
+  and mark it `unverified-hardware`. Do not soften it into "should work".
+
+An overstated claim is the only kind of damage in this project that reaches a
+stranger. Wrong code gets found; a wrong claim gets believed.
+
+## How a change moves
+
+Land it (small pull request, CI green), it ships to volunteers as a
+**pre-release**, and it becomes **stable** only once someone who owns each
+affected model has run it. Nothing waits on anybody's free time except the last
+step. Full rules in [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+## The commands
+
+`master` is protected: no direct pushes. Everything below assumes the remote is
+called `origin`. Replace `<name>` placeholders.
+
+**Once, to get set up**
+
+```bash
+git clone https://github.com/chery-connect-ha/omoda9-ha.git
+cd omoda9-ha
+gh auth status || gh auth login     # the GitHub CLI, for pull requests
+```
+
+**Start a piece of work — always from an up-to-date `master`**
+
+```bash
+git fetch origin
+git switch -c fix/<short-name> origin/master
+```
+
+Name it for the behaviour, not the file: `fix/charge-energy-undercount`, not
+`fix/coordinator`.
+
+**Save the work**
+
+```bash
+git add -A
+git commit -m "<what changed and why, in one line>"
+```
+
+Write the message for the person who will run `git blame` in a year. Reference
+the issue (`#12`) when there is one. Never add AI co-authorship trailers — how
+this project credits its tools is a decision for the group, not a default.
+
+**Run the checks locally if you can**
+
+```bash
+pip install -r requirements_test.txt
+pytest tests/ -q
+```
+
+Home Assistant needs Python 3.13+. If the local Python is older, skip it and let
+CI be the gate — that is why CI exists — but say so in the pull request.
+
+**Open the pull request**
+
+```bash
+git push -u origin HEAD
+gh pr create --fill
+```
+
+Then fill in the field-test block in the template. If you did not test on
+hardware, say it there rather than leaving it blank:
+
+```bash
+gh pr edit --add-label unverified-hardware
+```
+
+**When CI is red**
+
+```bash
+gh pr checks                    # what failed
+gh run view --log-failed        # why
+```
+
+Fix, commit, `git push`. The pull request updates itself; do not open a new one.
+
+**When `master` has moved on and the pull request shows a conflict**
+
+```bash
+git fetch origin
+git merge origin/master         # resolve, then:
+git commit
+git push
+```
+
+Use `merge`, not `rebase`. Rebasing a branch that is already pushed requires a
+force-push, and a force-push is how history gets lost by people who did not
+intend to lose it.
+
+**When review comes back**
+
+Make the changes on the same branch, commit, push. Do not close and reopen. Reply
+to the comment saying what you changed — a review is a conversation, and silence
+reads as disagreement.
+
+**Cutting a pre-release** (maintainers)
+
+```bash
+gh release create v<X.Y.Z> --prerelease --generate-notes
+```
+
+Volunteers pick it up by enabling *Show beta versions* for this repository in
+HACS. A stable release is `--latest` and requires the field tests described in
+`CONTRIBUTING.md`.
+
+## Getting out of trouble
+
+**"I committed on `master` by mistake" (locally, not pushed)**
+
+```bash
+git branch fix/<short-name>          # keep the work on a branch
+git reset --hard origin/master       # put master back
+git switch fix/<short-name>
+```
+
+**"I have changes and I'm on the wrong branch"**
+
+```bash
+git stash
+git switch -c fix/<short-name> origin/master
+git stash pop
+```
+
+**"I committed something secret"**
+
+Stop. Do not push. Do not open a pull request. Say so to the maintainers
+immediately — a secret that reached the remote has to be treated as leaked and
+rotated, and that is a different, much longer procedure than fixing it before it
+leaves the machine.
+
+**Never**: force-push a shared branch, rewrite published history, push straight
+to `master`, or bundle unrelated changes to "save time". Each of those turns a
+five-minute problem into somebody else's afternoon.
+
+## When you are not sure
+
+Open an issue and describe what you observed, rather than guessing in code. An
+observation nobody can explain yet is more valuable to this project than a fix
+nobody can verify — it is, quite literally, how every command we speak was found
+in the first place.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,12 @@ Land it (small pull request, CI green), it ships to volunteers as a
 affected model has run it. Nothing waits on anybody's free time except the last
 step. Full rules in [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
+A pull request can also be made installable **before** it lands — label it
+`beta` and a pre-release is cut from it. Reach for that whenever the change is
+written for a car you do not own: your instance cannot disprove it, and this is
+what puts it in front of the person whose instance can, while there is still
+time to change it.
+
 ## The commands
 
 `master` is protected: no direct pushes. Everything below assumes the remote is
@@ -151,6 +157,22 @@ hardware, say it there rather than leaving it blank:
 gh pr edit --add-label unverified-hardware
 ```
 
+**Get it onto a real car, before it lands**
+
+```bash
+gh pr edit --add-label beta
+```
+
+This publishes a pre-release built from the pull request, installable from HACS
+with *Show beta versions* on. Ask for it whenever the change touches a model
+nobody testing it here owns — including your own author's case, where the change
+is a no-op on your car and therefore unfalsifiable by you. Post the release link
+in the pull request and name who you are asking. Only write access can label, so
+a tester never has to run anything: they get a link.
+
+A beta is never cut from a fork. If this pull request comes from one, a member
+publishes it by hand after reading what is in it.
+
 **When CI is red**
 
 ```bash
@@ -179,15 +201,27 @@ Make the changes on the same branch, commit, push. Do not close and reopen. Repl
 to the comment saying what you changed — a review is a conversation, and silence
 reads as disagreement.
 
-**Cutting a pre-release** (maintainers)
+**Cutting a release** (maintainers)
+
+A pre-release from a pull request is the `beta` label — do not do it by hand.
+
+For a **stable**, the archive is not optional. `hacs.json` sets `zip_release`
+with `omoda9.zip`, so HACS installs *only* from a release carrying that asset:
+publish without it and HACS lists the version and then fails to install it,
+which is worse than not publishing at all.
 
 ```bash
-gh release create v<X.Y.Z> --prerelease --generate-notes
+# from a clean checkout of the commit you are releasing
+cd custom_components/omoda9
+git ls-files -z | xargs -0 zip -q -X ../../omoda9.zip
+cd -
+gh release create v<X.Y.Z> omoda9.zip --latest --generate-notes
 ```
 
-Volunteers pick it up by enabling *Show beta versions* for this repository in
-HACS. A stable release is `--latest` and requires the field tests described in
-`CONTRIBUTING.md`.
+Only tracked files, and the contents of `custom_components/omoda9/` sit at the
+root of the archive — that is where HACS expects them with
+`content_in_root: false`. The version in `manifest.json` must already match the
+tag. A stable also requires the field tests described in `CONTRIBUTING.md`.
 
 ## Getting out of trouble
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,8 @@ Adding a car should mean adding rows, not adding code paths.
 **How a change moves.** It **lands** — cheaply if it only touches your own car's
 data, with one read by somebody else if it touches shared code, and labelled
 `unverified-hardware` if it is written for a car none of us owns. It **ships as a
-pre-release**, so you have your own work on your own car the same day. It becomes
+pre-release** — on merge, or from the pull request itself if you label it `beta`
+— so you have your own work on your own car the same day. It becomes
 **stable** only once someone who owns each affected model has run it. Merging is
 never blocked. Only the last step is.
 
@@ -121,6 +122,13 @@ Merges go out as **pre-releases**. Anyone who wants them turns on *Show beta
 versions* for this repository in HACS and has them on their own car the same day.
 This is deliberate: nobody in this project should ever be separated from work they
 just did because they are waiting on somebody else's free time.
+
+**And it can ship before it lands.** Put the label `beta` on a pull request and a
+pre-release is built from it, installable the same way. That is what carries a
+change to the one person who can disprove it *while there is still time to change
+it* — which matters most exactly where the author is powerless: code written for a
+car they do not own is, on their own car, a no-op. It is two taps in a phone
+browser, and only write access can do it, so a tester never runs anything.
 
 ### 3. It becomes stable
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,191 @@
+# Contributing
+
+> **Status: proposed.** This document describes rules that have been agreed in
+> outline but not yet ratified, and it arrives as a pull request rather than as a
+> push to `master` — which is itself the first rule it asks for. Argue with the
+> text, not with whoever opened it.
+
+## In one page
+
+**What this is.** A Home Assistant integration for cars on the Chery telematics
+platform — OMODA, Jaecoo and their siblings. Unofficial, reverse-engineered,
+built by four people who each own one of these cars.
+
+**What is scarce here.** Not writing code: an agent writes faster than any of us
+can read. What is scarce is **checking** — and a check is what makes a claim true
+for somebody else's car. Everything below is bookkeeping for that.
+
+**Four things, kept apart on purpose.**
+
+| | what it is | who touches it |
+|---|---|---|
+| **The instrument** | `sandbox/` — log in, send a command, see the answer, with no Home Assistant involved | rarely anyone |
+| **The protocol** | authentication, signing, transport. No Home Assistant imports, so the sandbox can drive it | whoever reads code |
+| **The catalogue** | rows: *verb, body, subject, when, accepted, acted* — what a real car answered, on a date | **whoever owns a car** |
+| **The integration** | entities, state, the buttons people press | whoever reads code |
+
+Adding a car should mean adding rows, not adding code paths.
+
+**How a change moves.** It **lands** — cheaply if it only touches your own car's
+data, with one read by somebody else if it touches shared code, and labelled
+`unverified-hardware` if it is written for a car none of us owns. It **ships as a
+pre-release**, so you have your own work on your own car the same day. It becomes
+**stable** only once someone who owns each affected model has run it. Merging is
+never blocked. Only the last step is.
+
+**Who does what.** If you own a car, you are the only proving ground for it — and
+half of what we ship is written for models the author has never sat in. If you
+read code, you carry the reads. Nobody approves because they own the org.
+
+**The rest of this file** is the detail: the gates, the one-week rule, the
+labels, and the things never to do. The method for checking is in
+[`docs/field-test.md`](docs/field-test.md); the commands your coding agent needs
+are in [`AGENTS.md`](AGENTS.md).
+
+---
+
+None of the people who built this integration wrote it by hand. Each of us drove
+a model, on our own car, and the code arrived faster than any of us can read it:
+the runtime is over eleven thousand lines in a couple of months, and a single
+release once landed 4,500 lines in thirty-four hours. That is not a complaint —
+it is the engine of the project, and slowing it down would cost more than it
+saves.
+
+But it changes what is scarce. Writing is cheap here; **checking is expensive**,
+and checking is the only thing that makes a claim true for somebody else's car.
+So the currency of this project is not lines of code. It is **claims that have
+been checked**, and everything below is bookkeeping for that one idea.
+
+## Roles — each defined by what only you can do
+
+**Field authority.** If you own a car, you are the only proving ground for it.
+Nobody can buy their way around this, and it cannot be delegated: half of what
+we ship is written for models the author has never sat in, and on the author's
+own car that code is often a literal no-op — it cannot be falsified where it was
+written. Your car can falsify it. That is worth more than an approval on a diff.
+
+**Protocol source.** If you captured a telematics stack, you own the *method*.
+The method is universal, because the app is universal; the endpoints and commands
+you verified are specific to the car you verified them on. Both matter, and they
+are different artefacts: the method is written down once and published, the
+captures stay private and per-model. See [`docs/field-test.md`](docs/field-test.md).
+
+**Code reader.** If you read diffs, you carry the reads. There are fewer of you
+than of us, which is why the gate below is proportional rather than uniform.
+
+**Coordinator.** Keeps the plan current and the boundaries visible. No casting
+vote: the plan is a document to be argued with, not an office.
+
+**Nobody approves because they own the org.** An approval that isn't backed by
+either a read or a car is a signature, and a signature is worth nothing here.
+
+If you cannot read code, you are not a second-class maintainer in this project.
+You hold the only instrument that can disprove half of what we ship.
+
+| Who | Car | Region |
+|---|---|---|
+| @Caslinovich | Omoda 9 | IT |
+| @drake69 | Omoda 5 BEV Premium | IT |
+| @JackRonan | Omoda E5 | UK |
+| @GurliGebis | Jaecoo J5 EV | DK |
+
+If you own a Chery-platform car and are willing to run a check when asked, add
+yourself to the tested-models issue. You do not need to write code to be
+essential to this project.
+
+## How a change moves
+
+There are three moments, and only the third one is a gate on other people.
+
+### 1. It lands
+
+The cost of review is proportional to the blast radius, because a uniform tax
+prices the harmless change the same as the dangerous one — and then everybody
+routes around it.
+
+| What the change touches | What it needs to merge |
+|---|---|
+| Data or capabilities for a car **you own** | CI green |
+| **Shared code** — `core/`, `platform/`, `transport/`, `coordinator.py`, auth, signing, the entity model | CI green **+ one read by somebody other than the author** |
+| Behaviour for a car **nobody here owns** | CI green, merged with the `unverified-hardware` label |
+
+The third row is the important one. Code written for a model you cannot test is
+**not blocked** — it merges, and it merges honestly labelled. What you may not do
+is *claim* it works. Merging is a statement about the code; the label is a
+statement about the evidence, and only the second one can be wrong in a way that
+reaches a stranger's car.
+
+### 2. It ships to the people who asked for it
+
+Merges go out as **pre-releases**. Anyone who wants them turns on *Show beta
+versions* for this repository in HACS and has them on their own car the same day.
+This is deliberate: nobody in this project should ever be separated from work they
+just did because they are waiting on somebody else's free time.
+
+### 3. It becomes stable
+
+**This is the only real gate.** A stable release is a statement to strangers, so
+before one is cut:
+
+- every model in the blast radius of the changes has had a field test — one
+  report, from someone who owns that car, in the form described in
+  [`docs/field-test.md`](docs/field-test.md);
+- anything still carrying `unverified-hardware` is named as such in the release
+  notes, rather than being quietly folded in;
+- the suite is green and the entity count is unchanged (`tests/test_entity_count.py`),
+  which is checked by CI and not by anybody's memory.
+
+A stable release may therefore ship unverified code. It may not ship unverified
+code *silently*.
+
+## The one-week rule
+
+A read is promised within **one week**. If nobody has read it by then, the author
+merges it themselves and labels it `merged-unread`.
+
+This is not a loophole, it is the point: the rule must fail loudly instead of
+stopping everyone. If `merged-unread` starts appearing regularly, the rule has
+failed and we drop it — better an honest record of what nobody read than a queue
+of pull requests that quietly teaches everyone to stop opening them.
+
+## Keep changes small
+
+A large change is one nobody can review, and asking for review of an unreviewable
+diff is theatre. One behaviour per pull request; a behaviour that needs sixteen
+files is telling you something about the architecture, not about your discipline.
+
+If you have been working offline for a while and have a pile of improvements,
+open them one at a time rather than as one bundle. It is more work for you and
+much less work for everyone else.
+
+## Labels, and the matrix that comes out of them
+
+- `verified:<model>` — somebody with that car ran it and reported.
+- `unverified-hardware` — written for a model none of us could test.
+- `needs-field-test:<model>` — a specific ask, waiting for a specific car.
+- `merged-unread` — merged because the week elapsed.
+
+The tested-models matrix is generated from these. It is not documentation to be
+kept by hand: it is the register of **who can check what**, which is the same
+question as who can review what.
+
+## Never
+
+- **Push to `master`.** Everything lands as a pull request, including from the
+  people who wrote this file.
+- **Commit a VIN, a token, a certificate, a user id, or a raw capture.** They
+  turn up in logs far more often than you would expect. Redact first; captures
+  belong in the private channel, never in this repository.
+- **Claim hardware verification you do not have.** "The backend accepted it" is
+  not "the car did it". If you did not watch the car, say so.
+- **Remove a function that worked for somebody.** When in doubt the code fails
+  open: unknown, unreadable or timed-out means *send exactly as before*. The worst
+  an untested path may do is fail to help.
+
+## The mechanics
+
+If you are working with a coding agent — and most of us are — point it at
+[`AGENTS.md`](AGENTS.md) before it touches anything. It carries the invariants
+above plus the literal git and GitHub commands for branching, opening a pull
+request, syncing and getting out of trouble. You are not expected to know
+GitHub to contribute here.

--- a/docs/field-test.md
+++ b/docs/field-test.md
@@ -1,0 +1,154 @@
+# Field test — how we check that the car did it
+
+Half of what this project ships is written for cars the author has never sat in.
+That is not sloppiness, it is the shape of the problem: one person captured the
+protocol on one model, and the fix for somebody else's model is, on the author's
+own car, a literal no-op — it cannot be proved or disproved where it was written.
+A field test is how that gap gets closed, and it is the one contribution that
+cannot be delegated to whoever is most comfortable with code.
+
+The method below is not new. It is what was already being done, written down so
+that anyone with a car and half an hour can repeat it.
+
+## The two layers
+
+Almost every mistaken claim in this project comes from confusing them.
+
+**Layer one — the backend accepted.** The request was well formed, signed, and
+authorised. `operation.successful`. This says something about *us*.
+
+**Layer two — the car acted.** A state field the vehicle reports changed, at a
+time you can point to. This is the only layer that says anything about the car.
+
+A command is verified at layer two or it is not verified. `HTTP 200` with
+`code: 1` has been observed on a request the backend then refused at application
+level, and a comfort macro has been seen to return success while the car cooled
+down and switched itself off — the acceptance was real and the outcome was wrong.
+
+## The procedure
+
+**1. Write the prediction before you press anything.** One sentence: *"if I send
+X, field Y should become Z within N seconds."* Written afterwards it is a story;
+written beforehand it can be wrong, which is the entire value.
+
+**2. Change one variable.** One field, one command, one setting. Two changes at
+once produce a result nobody can attribute — and the refusals here are total: a
+single denied field makes the backend reject the whole request, including the
+parts the vehicle would have authorised. That is exactly the kind of finding a
+single-variable test produces and a multi-variable one hides.
+
+**3. Record the time.** Wall-clock, to the second, for the command and for the
+observed change. Timing is not decoration: an ordering defect in the climate
+macros was found only because "off" pressed first left the queue *after* "on"
+pressed ten seconds later, and a warning meant for the user was found to have
+lived for twelve milliseconds before the next message overwrote it. Neither is
+visible without timestamps.
+
+**4. Confirm on a state field, not on the button.** Name the field and its value.
+A switch that stays on proves nothing about the car.
+
+**5. Confirm the negative too.** Send the opposite command and watch it come back.
+A test that only ever moves one way cannot distinguish "the car obeyed" from "the
+field was already there".
+
+**6. Say what you could not test.** The gap is part of the result. "The car does
+not have that hardware" and "I did not try" are both useful, and they are
+different.
+
+## What a report is: one row
+
+A report is not prose that somebody later turns into data. It **is** the row —
+the same shape the model catalogue stores, so the sandbox can emit it for you.
+
+```
+verb:      windowControl
+body:      {controlType: open, windowType: 2}    <- the one thing you varied
+subject:   Omoda 9 - IT - fw <x> - declared: [...]
+when:      2026-06-20 19:43:58
+accepted:  A00079
+acted:     fWinHeatingState 0 -> 1 at 19:44:12   <- empty if you did not watch
+not tested: rear glass heating: different function, different state field
+```
+
+Four things, and the two people forget are the **body** and the **when**.
+
+**The body, not just the verb.** The outcome is a function of what you sent, not
+of the command's name. Changing only `cycleData` turned `[1,3,5]` into `A00084`
+and `[1..7]` into `A00079`; changing only whether `backDefrosting` was present
+flipped refusal into acceptance. One denied field makes the backend reject the
+whole request, including the parts the car would have allowed.
+
+**The when, because an outcome is an observation and not a property.** The same
+car accepted a comfort macro four times in one day and refused it that evening.
+A row may say "on this vehicle, with this body, at this time, the answer was
+A00084". It may not say "this model cannot".
+
+**The subject is the vehicle, not the model.** Two cars of the same model on the
+same firmware do not necessarily accept the same commands, because what a car
+can do is declared by the backend per vehicle. Model and region are the label we
+group by, and the grouping is convenient rather than exact.
+
+**Refusals are worth as much as successes.** `A00084` and `A00079` are the rows
+that draw the boundary. A catalogue of successes alone teaches nobody anything.
+
+**And the catalogue describes; it never decides.** It must not gate what the
+integration sends: a stale row would take a working function away from someone,
+which is precisely what failing open forbids. At runtime, capabilities
+discovered from the car win. The rows are for people, for diagnosis, and for the
+tested-models matrix.
+
+Two examples of the method earning its keep. The defrost above was taken all the
+way to the state field rather than stopping at "the backend accepted", which is
+also what made it clear that it is a *different* function from the electric
+heating of the rear glass: merging the two is the easy regression, and there is
+now a test against it. And the discovery that one denied field poisons a whole
+request came from two single-variable experiments with the prediction written
+down first.
+
+## Two instruments, and what each can prove
+
+**The sandbox — no Home Assistant needed.** `sandbox/` runs the integration's real
+authentication and signing code outside Home Assistant: a small GUI and a CLI over
+the same core, with an isolated token, live status, point-and-click commands and
+the raw JSON of every answer. It already carries single-variable experiments that
+classify a response as accepted or refused by its code. You need the car, your
+email and PIN, and Python — not an instance, and not a deploy.
+
+This is the instrument for anything about the protocol: whether a command is
+accepted, what a vehicle declares it can do, what a field is called. It reads
+telemetry back, so it reaches layer two on its own for everything the car
+reports.
+
+*Not in this repository yet — it comes with the port of the fork line.*
+
+**Your Home Assistant instance.** The sandbox cannot prove that an entity exists,
+shows the right state, or that pressing the button in the UI reaches the car.
+That path is only real in an instance, and pre-releases exist for it: turn on
+*Show beta versions* for this repository in HACS.
+
+If you have a spare machine or a container, keep a second instance for this. A
+pre-release on the instance you rely on every day is a bet with your own car.
+
+Rule of thumb, and it matches the table in `CONTRIBUTING.md`: changes to
+`core/`, `platform/` or signing are proved in the sandbox; changes to entities,
+state or the coordinator are proved in an instance.
+
+## Redact before you post
+
+No VIN, no token, no certificate, no account or user id — the last one turns up
+in logs far more often than people expect. Replace with `<VIN>`, `<token>`. If in
+doubt, post the shape and not the value: `"vin": "<redacted, 17 chars>"` tells us
+everything we needed.
+
+## What this produces
+
+Not a patch. A **row of data**: this model, this region, this firmware, this
+command, this outcome, this date. The integration then treats a car as data plus
+capabilities discovered at runtime — so the next model is a row, not a new code
+path, and the tested-models matrix is generated from the rows instead of being
+kept by hand.
+
+Which is the whole argument for writing reports rather than special cases: the
+capture is specific to one car, but the *method* is universal, because the app is
+universal. What generalises is not the finding. It is the procedure that produced
+it.


### PR DESCRIPTION
If you read one thing, read the first page of `CONTRIBUTING.md` — the whole
arrangement is there. The rest is detail you can argue with later.

@Caslinovich asked whether to release the SMS fix directly or open a pull request.
This is my answer, and it comes as a pull request rather than a push to `master` —
which is the first thing it asks for.

Three ideas, and they are the parts worth arguing with:

1. **The gate is proportional.** Data for a car you own: merge. Shared code: one
   read by someone else. Code for a car nobody here owns: merge, labelled
   `unverified-hardware`. A uniform rule prices the harmless change like the
   dangerous one, and then everybody routes around it.

2. **Merging is never blocked; the stable release is.** Merges go out as
   pre-releases, so you have your own work on your own car the same day. A stable
   release needs a field test on each affected model — and may ship unverified
   code, but never silently.

3. **"My approval would be a signature, not a review"** — @Caslinovich, I disagree,
   and this is why. A read of the diff is one kind of review. Running it on your
   Omoda 9 is the other, and it is the one none of the rest of us can do. Half of
   what we ship is written for cars the author does not own; your car is the only
   instrument that can disprove it. `docs/field-test.md` writes down the method you
   were already using — including the part I think is the real finding: an outcome
   is an observation with a date on it, not a property of a model.

One thing I cannot answer for you: when you try something out, do you put it on the
Home Assistant instance you use every day, or somewhere safer? It matters here. The
sandbox in the fork line already exercises the protocol with no instance at all —
the real auth and signing code, live status, commands, raw answers — and it only
works because `core/` has no Home Assistant in it. It should come across with the
port, plus the one thing it lacks: writing its result to a file you can paste into
a pull request instead of reading it off the screen. `docs/field-test.md` says which
claims each instrument can support.

`AGENTS.md` is the practical half: none of us writes this by hand, so the file that
tells our agents how the project works belongs in the repository, with the exact
commands. Nobody should need to learn git to contribute here.

Two notes on scope. The links to `docs/design/` point at #6 and are marked as such,
so this stands on its own if #6 is rejected. And no `CODEOWNERS` yet — the paths it
would name do not exist until the layering lands.

Nothing here is settled and nothing moves before 31 August. If a rule looks like it
would slow you down more than it helps, say so — that is the verdict I want.
