### PR TITLE
Fix SMS/mobile login: identity order + clearer no-vehicle error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ dell'integrazione: aggiorna da **HACS → Omoda 9 / Jaecoo → Aggiorna**.
 
 ## [Non rilasciato]
 
+## v1.14.0 — 2026-08-24
+
+### 🇮🇹 Italiano
+
+- **Il login via SMS ora funziona, anche per gli account registrati solo col numero.** Chi accedeva col numero di telefono invece che con l'email otteneva sempre un errore, anche col codice giusto: l'integrazione componeva l'identità dell'account **nell'ordine sbagliato** (prefisso e numero invertiti) e coniava un token per un account fantasma vuoto, senza veicoli. Ora l'ordine è quello corretto — confermato sia dal vivo sia leggendo il programma dell'app ufficiale — e il login via SMS raggiunge il tuo account reale, con la tua auto.
+- **Un messaggio chiaro quando l'account non ha un'auto.** Se il codice era corretto ma su quell'account non risulta nessun veicolo, prima compariva «codice non valido», mandandoti a ricontrollare un OTP che invece andava benissimo. Adesso te lo diciamo com'è davvero: il codice è giusto, ma non c'è un'auto collegata a quell'account.
+- **Numero di telefono più protetto nei file di diagnostica.** La regola che nasconde il numero nei log è stata resa più robusta, così non può sfuggire per un caso di forma inattesa: nel dubbio nasconde di più, mai di meno.
+
+### 🇬🇧 English
+
+- **SMS sign-in now works, including for accounts registered with a phone number only.** Signing in with a phone number instead of an email always failed, even with the right code: the integration built the account identity **in the wrong order** (area code and number swapped) and minted a token for an empty phantom account with no vehicles. The order is now correct — confirmed both live and by reading the official app — so SMS sign-in reaches your real account and your car.
+- **A clear message when the account has no car.** If the code was correct but that account has no vehicle on it, it used to say "invalid code", sending you to re-check an OTP that was actually fine. Now it tells you what is really going on: the code is right, but there is no car linked to that account.
+- **Safer phone-number redaction in the diagnostics file.** The rule that hides the number in logs was hardened so it cannot slip through on an unexpected shape: when in doubt it masks more, never less.
+
 ## v1.13.0 — 2026-08-10
 
 ### 🇮🇹 Italiano

--- a/README.it.md
+++ b/README.it.md
@@ -195,7 +195,7 @@ o telefono) + OTP. Catena orchestrata dal config flow (codice in
 |---|---|---|
 | invio OTP (email) | `login_omoda.py invia <email>` | risolve il captcha del gateway (§2) e fa partire il codice via **email** |
 | invio OTP (SMS) | `login_omoda.py invia-sms <numero-senza-prefisso> <prefisso>` | idem via `sendSmsCode` — l'unico endpoint dietro un WAF Aliyun che filtra sull'**impronta TLS**, gestito da `tls_client.py` |
-| conio token | `prova_token.py <email> <code>` | chiama `/auth/oauth2/token` replicando l'app (cifratura SM4) e salva il token. Per gli account col numero l'identità è la composita `APP-LOGIN@<numero>_<area>` |
+| conio token | `prova_token.py <email> <code>` | chiama `/auth/oauth2/token` replicando l'app (cifratura SM4) e salva il token. Per gli account col numero l'identità è la composita `APP-LOGIN@<area>_<numero>` (prima il prefisso, poi il numero — confermato in `UserService::phoneVerifyLogin`) |
 | orchestrazione | `session.py` | espone `request_otp()` / `confirm_otp(code)` / `check()` / `refresh()` |
 
 Il **PIN non c'entra con l'accesso**: è l'OTP a coniare il token, il PIN firma

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ phone) + OTP. Chain orchestrated by the config flow (code in
 |---|---|---|
 | send OTP (email) | `login_omoda.py invia <email>` | solves the gateway captcha (§2) and triggers the code by **email** |
 | send OTP (SMS) | `login_omoda.py invia-sms <number-without-country-code> <country-code>` | same, via `sendSmsCode` — the one endpoint behind an Aliyun WAF that filters on the **TLS fingerprint**, handled by `tls_client.py` |
-| mint token | `prova_token.py <email> <code>` | calls `/auth/oauth2/token` replicating the app (SM4 encryption) and saves the token. For phone accounts the identity is the composite `APP-LOGIN@<number>_<area>` |
+| mint token | `prova_token.py <email> <code>` | calls `/auth/oauth2/token` replicating the app (SM4 encryption) and saves the token. For phone accounts the identity is the composite `APP-LOGIN@<area>_<number>` (area code first, then number — confirmed in `UserService::phoneVerifyLogin`) |
 | orchestration | `session.py` | exposes `request_otp()` / `confirm_otp(code)` / `check()` / `refresh()` |
 
 The **PIN plays no part in signing in**: the OTP mints the token, the PIN only

--- a/custom_components/omoda9/config_flow.py
+++ b/custom_components/omoda9/config_flow.py
@@ -149,11 +149,11 @@ _MAX_CIFRE_PREFISSO = 3          # E.164: i prefissi paese hanno 1, 2 o 3 cifre.
 
 def _normalizza_telefono(numero: str | None, prefisso: str | None) -> tuple[str, str]:
     """Ripulisce numero e prefisso UNA VOLTA SOLA, qui: da qui in poi viaggiano in entry.data,
-    nell'ambiente dei sottoprocessi e nell'identità `APP-LOGIN@<num>_<area>`, e a valle nessuno
+    nell'ambiente dei sottoprocessi e nell'identità `APP-LOGIN@<area>_<num>`, e a valle nessuno
     li tocca più (`invia_sms` fa solo `lstrip("+")` + spazi, `build_params_mobile` altrettanto).
 
     Cose che la gente scrive davvero e che senza questo passaggio arrivano storte al server:
-      * numero copiato dalla rubrica col prefisso già dentro → identità `APP-LOGIN@39<num>_39`;
+      * numero copiato dalla rubrica col prefisso già dentro → identità `APP-LOGIN@39_39<num>`;
       * separatori dentro il numero: spazi, punti, trattini;
       * prefisso scritto `+39` o `0039` → `areaCode="+39"`, che il server non riconosce;
       * zero di accesso nazionale davanti al numero (Regno Unito, Germania, Francia…).

--- a/custom_components/omoda9/config_flow.py
+++ b/custom_components/omoda9/config_flow.py
@@ -64,6 +64,22 @@ def _pending_token_path(hass: HomeAssistant) -> str:
     return hass.config.path(f"{DOMAIN}_pending_token.json")
 
 
+def _pending_token_minted(hass: HomeAssistant) -> bool:
+    """True se un token è stato davvero SCRITTO (OTP valido), anche quando `confirm_otp` ha poi
+    riportato un fallimento perché il login post-conio non è riuscito — di norma perché l'account
+    NON ha veicoli. Serve a distinguere «codice sbagliato» (nessun token) da «codice giusto ma
+    niente auto sull'account»: il primo è `otp_invalid`, il secondo `no_vehicle`, e finché non li
+    si separava un login sull'account sbagliato usciva come «OTP non valido», mandando l'utente a
+    ricontrollare all'infinito un codice che era corretto."""
+    try:
+        with open(_pending_token_path(hass), encoding="utf-8") as fh:
+            tok = json.load(fh)
+    except Exception:  # noqa: BLE001
+        return False
+    d = tok.get("data", tok) if isinstance(tok, dict) else {}
+    return bool(d.get("access_token") if isinstance(d, dict) else None)
+
+
 def _reason_line(detail: str | None) -> str:
     """Riga col motivo del fallimento, mostrata sotto il form (vuota se non c'è). Il dettaglio è
     la coda dell'output del sottoprocesso di login (stato HTTP / chiave del server tipo
@@ -428,7 +444,13 @@ class Omoda9ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             ok, msg = await self.hass.async_add_executor_job(
                 _mint_token, self.hass, self._data, user_input["code"].strip()
             )
-            if ok:
+            # Anche se `confirm_otp` riporta KO, il token può ESSERE stato coniato (OTP valido):
+            # a fallire è allora il login post-conio, di norma perché l'account non ha veicoli.
+            # Distinguo i due casi dal fatto che un token sia stato scritto, così un login
+            # sull'account sbagliato non esce più come «OTP non valido».
+            minted = ok or await self.hass.async_add_executor_job(
+                _pending_token_minted, self.hass)
+            if minted:
                 d_ok, tu, vins, detail = await self.hass.async_add_executor_job(
                     _discover, self.hass, self._data
                 )
@@ -445,7 +467,7 @@ class Omoda9ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         return await self._create_entry(vins[0])
                     return await self.async_step_select_vehicle()
             else:
-                # OTP errato/scaduto: butta il pending eventualmente già scritto.
+                # Nessun token scritto → il CODICE è stato davvero rifiutato (errato/scaduto).
                 await self.hass.async_add_executor_job(_cleanup_pending, self.hass)
                 errors["base"] = "otp_invalid"
                 reason = _reason_line(msg)

--- a/custom_components/omoda9/core/login_omoda.py
+++ b/custom_components/omoda9/core/login_omoda.py
@@ -225,7 +225,7 @@ if __name__ == "__main__":
         # ⚠️ Il conio del token per gli account SMS NON si fa da qui. Le combinazioni che
         # `_combos_sms` prova (numero nudo, codice in chiaro, parametri in query) sono quelle
         # tentate PRIMA di sapere come funziona davvero, e il server le rifiuta tutte: la forma
-        # buona — identità composita `APP-LOGIN@<num>_<area>`, codice cifrato SM4, parametri
+        # buona — identità composita `APP-LOGIN@<area>_<num>`, codice cifrato SM4, parametri
         # nel body — è in `prova_token.build_params_mobile`, ricavata decompilando l'app e
         # confermata dal vivo. Lasciare qui un sottocomando che non può funzionare significa
         # che chi lo usa per diagnosticare conclude «il server rifiuta il mio codice».

--- a/custom_components/omoda9/core/mask.py
+++ b/custom_components/omoda9/core/mask.py
@@ -99,11 +99,16 @@ def indirizzo_email(valore) -> str:
 
 
 def identita_mobile(valore) -> str:
-    """`APP-LOGIN@<numero>_<prefisso>` → `APP-LOGIN@***1234_39`.
+    """`APP-LOGIN@<prefisso>_<numero>` → `APP-LOGIN@39_***1234`.
 
     Tiene la FORMA dell'identità composita — che è poi ciò che si sta verificando quando si
     legge un log di login — e butta il numero. Se la stringa non ha la forma attesa non si
-    tira a indovinare: si maschera tutto tranne la coda."""
+    tira a indovinare: si maschera tutto tranne la coda.
+
+    ⚠️ ORDINE: l'identità è `<prefisso>_<numero>` (prefisso prima, numero dopo — vedi
+    `prova_token.build_params_mobile`). Il pezzo da OSCURARE è il SECONDO (il numero); il primo
+    è il solo prefisso internazionale, non sensibile. Con l'ordine sbagliato qui si mascherava
+    il prefisso e il numero usciva in chiaro nei log."""
     s = str(valore or "")
     testa, chiocciola, coda = s.rpartition("@")
     # ⚠️ La testa si ristampa SOLO se è il modulo che ci aspettiamo. `rpartition` da sola non
@@ -118,8 +123,8 @@ def identita_mobile(valore) -> str:
     modulo_noto = bool(chiocciola) and testa.isascii() and testa.isupper() \
         and testa.replace("-", "").isalpha()
     corpo = coda if chiocciola else s
-    num, sep, area = corpo.rpartition("_")
+    area, sep, num = corpo.partition("_")         # ordine: <prefisso>_<numero>
     prefisso_testa = f"{testa}@" if modulo_noto else ""
     if not sep:                                   # forma inattesa: nessuna deduzione
         return f"{prefisso_testa}{numero(corpo)}"
-    return f"{prefisso_testa}{numero(num)}{sep}{area}"
+    return f"{prefisso_testa}{area}{sep}{numero(num)}"

--- a/custom_components/omoda9/core/mask.py
+++ b/custom_components/omoda9/core/mask.py
@@ -52,6 +52,13 @@ MIN_NASCOSTE = 2
 
 OSCURATO = "***"
 
+# Un prefisso internazionale ha 1–3 cifre (E.164): è lo stesso limite che il config flow
+# impone in ingresso (`config_flow._MAX_CIFRE_PREFISSO`). Duplicato qui di proposito — `core/`
+# non importa il layer di Home Assistant — così la mascheratura resta autonoma. Serve a
+# `identita_mobile`: il PRIMO campo dell'identità composita si ristampa solo se è davvero un
+# prefisso; qualunque altra cosa (un dominio, un nome) va mascherata.
+MAX_CIFRE_PREFISSO = 3
+
 
 def solo_cifre(valore) -> str:
     return "".join(ch for ch in str(valore or "") if ch.isdigit())
@@ -98,6 +105,13 @@ def indirizzo_email(valore) -> str:
     return f"{locale[0]}{OSCURATO}@{dominio}"
 
 
+def _e_prefisso(campo: str) -> bool:
+    """Il primo campo dell'identità è un prefisso internazionale solo se sono 1–3 cifre. Tutto
+    il resto — un dominio come `rossi.it`, un nome — non lo si conosce e va mascherato: nel
+    dubbio si nasconde di più."""
+    return campo.isdigit() and 1 <= len(campo) <= MAX_CIFRE_PREFISSO
+
+
 def identita_mobile(valore) -> str:
     """`APP-LOGIN@<prefisso>_<numero>` → `APP-LOGIN@39_***1234`.
 
@@ -106,9 +120,14 @@ def identita_mobile(valore) -> str:
     tira a indovinare: si maschera tutto tranne la coda.
 
     ⚠️ ORDINE: l'identità è `<prefisso>_<numero>` (prefisso prima, numero dopo — vedi
-    `prova_token.build_params_mobile`). Il pezzo da OSCURARE è il SECONDO (il numero); il primo
-    è il solo prefisso internazionale, non sensibile. Con l'ordine sbagliato qui si mascherava
-    il prefisso e il numero usciva in chiaro nei log."""
+    `prova_token.build_params_mobile`, confermato nel decompilato: `UserService::phoneVerifyLogin`
+    costruisce `APP-LOGIN@{areaCode}_{number}`). Il pezzo da OSCURARE è il SECONDO (il numero).
+
+    ⚠️ Il PRIMO campo NON si ristampa «perché è il primo»: position è proprio l'assunzione che ha
+    prodotto il bug dell'ordine invertito. Lo si ristampa solo se è DAVVERO un prefisso di
+    chiamata (`_e_prefisso`: 1–3 cifre). Con un ingresso malformato come `mario@rossi.it_39` il
+    primo campo sarebbe `rossi.it` — un dominio, non un prefisso — e uscirebbe in chiaro; qui
+    viene mascherato insieme al resto. L'unico errore possibile diventa mascherare troppo."""
     s = str(valore or "")
     testa, chiocciola, coda = s.rpartition("@")
     # ⚠️ La testa si ristampa SOLO se è il modulo che ci aspettiamo. `rpartition` da sola non
@@ -127,4 +146,7 @@ def identita_mobile(valore) -> str:
     prefisso_testa = f"{testa}@" if modulo_noto else ""
     if not sep:                                   # forma inattesa: nessuna deduzione
         return f"{prefisso_testa}{numero(corpo)}"
-    return f"{prefisso_testa}{area}{sep}{numero(num)}"
+    if _e_prefisso(area):                         # primo campo = prefisso vero → si ristampa
+        return f"{prefisso_testa}{area}{sep}{numero(num)}"
+    # primo campo NON è un prefisso (dominio, nome, numero fuori posto): si maschera anche quello
+    return f"{prefisso_testa}{numero(area)}{sep}{numero(num)}"

--- a/custom_components/omoda9/core/prova_token.py
+++ b/custom_components/omoda9/core/prova_token.py
@@ -52,14 +52,22 @@ def _dept(area):
 
 
 def build_params_mobile(phone, area, code, codefmt="plain"):
-    """Parametri per il login MOBILE (SMS). Forma ESATTA dell'app, dal dump Dart
-    `UserService::phoneVerifyLogin`: l'identità è la stringa COMPOSITA
-    `APP-LOGIN@<numeroNazionale>_<areaCode>` (NON il numero nudo) e il codice è SM4 come
-    l'email. NB: questi vanno inviati nel BODY, non in query (vedi `call`)."""
+    """Parametri per il login MOBILE (SMS). L'identità è la stringa COMPOSITA
+    `APP-LOGIN@<areaCode>_<numeroNazionale>` (prefisso PRIMA, numero DOPO) e il codice è SM4
+    come l'email. NB: questi vanno inviati nel BODY, non in query (vedi `call`).
+
+    ⚠️ ORDINE — verificato dal vivo (2026-08-24) confrontando due login sullo STESSO account
+    Omoda (numero + e-mail): l'ordine `<numero>_<area>` fa risolvere il backend a un account
+    FANTASMA vuoto (crea un utente con `areaCode`/`phone` invertiti, senza veicoli né utente TSP
+    → `getTuserId` = "0", `login` = `app.service.failed`), mentre `<area>_<numero>` risolve
+    all'account REALE con il veicolo (stesso tUserId del login e-mail). Era la causa del
+    fallimento di OGNI login via SMS: si coniava un token per un account sbagliato. L'app
+    ufficiale usa quest'ordine (prefisso_numero), coerente con come il profilo memorizza il dato
+    (`areaCode`=prefisso, `phone`=numero)."""
     phone = str(phone).lstrip("+").replace(" ", "")
     cv = code if codefmt == "raw" else A.sm4_code(code, codefmt)
     return {
-        "mobile": f"APP-LOGIN@{phone}_{area}",
+        "mobile": f"APP-LOGIN@{area}_{phone}",
         "code": cv,
         "needDecode": "0",
         "grant_type": "mobile",

--- a/custom_components/omoda9/core/prova_token.py
+++ b/custom_components/omoda9/core/prova_token.py
@@ -63,7 +63,16 @@ def build_params_mobile(phone, area, code, codefmt="plain"):
     all'account REALE con il veicolo (stesso tUserId del login e-mail). Era la causa del
     fallimento di OGNI login via SMS: si coniava un token per un account sbagliato. L'app
     ufficiale usa quest'ordine (prefisso_numero), coerente con come il profilo memorizza il dato
-    (`areaCode`=prefisso, `phone`=numero)."""
+    (`areaCode`=prefisso, `phone`=numero).
+
+    Confermato anche nel DECOMPILATO (non solo dal confronto live): `UserService::phoneVerifyLogin`
+    costruisce `APP-LOGIN@{arg2}_{arg3}`, e `isValidPhoneNum2(receiver=arg3, argument=arg2)` chiama
+    `AreaString.phoneMaxInputLength(arg2)` sul prefisso e `splitPhoneNumber(arg3)` (che ne stacca il
+    prefisso davanti) sul numero → `arg2`=areaCode, `arg3`=number. Un `200 operation.successful` da
+    solo NON conferma l'ordine: dice che la richiesta era ben formata, non a quale account è arrivata.
+    Sull'account giusto la controprova è `GET /marketing/v1/app/user`, che rende `phone`/`areaCode`
+    nei campi corretti, e — con un veicolo — il `queryList` non vuoto (NON `tUserId`: "0" vale anche
+    «nessun utente TSP mappato»)."""
     phone = str(phone).lstrip("+").replace(" ", "")
     cv = code if codefmt == "raw" else A.sm4_code(code, codefmt)
     return {
@@ -118,7 +127,7 @@ def call(email, code, secret="prod", emailfmt="module", codefmt="plain", verbose
 
 
 def _mask_identity(mobile):
-    """`APP-LOGIN@<numero>_<prefisso>` → `APP-LOGIN@***<ultime 4>_<prefisso>`: tiene la forma
+    """`APP-LOGIN@<prefisso>_<numero>` → `APP-LOGIN@<prefisso>_***<ultime 4>`: tiene la forma
     dell'identità (che è poi ciò che si sta verificando) e butta il numero. Lo stdout di questo
     script viene loggato da Home Assistant, e i log finiscono nelle issue pubbliche.
 

--- a/custom_components/omoda9/manifest.json
+++ b/custom_components/omoda9/manifest.json
@@ -14,5 +14,5 @@
     "numpy>=1.21",
     "pillow>=9.0"
   ],
-  "version": "1.13.0"
+  "version": "1.14.0"
 }

--- a/custom_components/omoda9/strings.json
+++ b/custom_components/omoda9/strings.json
@@ -103,7 +103,7 @@
     "error": {
       "otp_send_failed": "Could not send the code. Check the email/phone and PIN and try again.",
       "otp_invalid": "Invalid or expired OTP code.",
-      "no_vehicle": "Login succeeded but no vehicle was found on this account.",
+      "no_vehicle": "Signed in, but this account has no vehicles. If your car is registered under a different login (e.g. your email address), sign in with that one instead.",
       "pin_required": "Enter the vehicle control PIN.",
       "otp_required": "Enter the code you received.",
       "phone_invalid": "That phone number does not look right. Enter the digits of the number only, without the country code and without spaces; in the other field put only the digits of the country code (Italy = 39).",

--- a/custom_components/omoda9/translations/en.json
+++ b/custom_components/omoda9/translations/en.json
@@ -103,7 +103,7 @@
     "error": {
       "otp_send_failed": "Could not send the code. Check the email/phone and PIN and try again.",
       "otp_invalid": "Invalid or expired OTP code.",
-      "no_vehicle": "Login succeeded but no vehicle was found on this account.",
+      "no_vehicle": "Signed in, but this account has no vehicles. If your car is registered under a different login (e.g. your email address), sign in with that one instead.",
       "pin_required": "Enter the vehicle control PIN.",
       "otp_required": "Enter the code you received.",
       "phone_invalid": "That phone number does not look right. Enter the digits of the number only, without the country code and without spaces; in the other field put only the digits of the country code (Italy = 39).",

--- a/custom_components/omoda9/translations/it.json
+++ b/custom_components/omoda9/translations/it.json
@@ -103,7 +103,7 @@
     "error": {
       "otp_send_failed": "Impossibile inviare il codice. Controlla email/telefono e PIN e riprova.",
       "otp_invalid": "Codice OTP non valido o scaduto.",
-      "no_vehicle": "Login riuscito ma nessun veicolo trovato su questo account.",
+      "no_vehicle": "Accesso riuscito, ma questo account non ha veicoli. Se l'auto è registrata su un altro accesso (es. la tua e-mail), usa quello.",
       "pin_required": "Inserisci il PIN di controllo veicolo.",
       "otp_required": "Inserisci il codice che hai ricevuto.",
       "phone_invalid": "Questo numero non sembra giusto. Scrivi solo le cifre del numero, senza prefisso internazionale e senza spazi; nell'altro campo metti solo le cifre del prefisso (Italia = 39).",

--- a/tests/test_login_sms.py
+++ b/tests/test_login_sms.py
@@ -5,7 +5,9 @@ Perché questi test esistono. La forma del login mobile non è documentata da ne
 sola contro il server vero. Sono quattro dettagli che sembrano arbitrari e che, se qualcuno
 li «riordina» in buona fede, fanno fallire il login con un messaggio che accusa il codice OTP:
 
-  * l'identità NON è il numero, è la stringa composita `APP-LOGIN@<numero>_<prefisso>`;
+  * l'identità NON è il numero, è la stringa composita `APP-LOGIN@<prefisso>_<numero>`
+    (prefisso PRIMA, numero DOPO — `UserService::phoneVerifyLogin` costruisce
+    `APP-LOGIN@{areaCode}_{number}`; l'ordine invertito conia un token ma verso l'account sbagliato);
   * `grant_type=mobile` (non `email`, non `sms`);
   * i parametri viaggiano nel **BODY**, mentre il ramo e-mail li manda in **QUERY**;
   * il codice è cifrato SM4 come nel ramo e-mail, non in chiaro.
@@ -27,11 +29,12 @@ import fixtures as FX
 # ───────────────────────── forma delle richieste ─────────────────────────
 
 def test_identita_mobile_e_composita(core):
-    """`APP-LOGIN@<numero>_<prefisso>`: il numero nudo NON funziona (verificato dal vivo)."""
+    """`APP-LOGIN@<prefisso>_<numero>` (prefisso PRIMA): il numero nudo NON funziona, e nemmeno
+    l'ordine invertito — quello conia un token ma verso un altro account (verificato dal vivo)."""
     pt = core["prova_token"]
     p = pt.build_params_mobile(FX.PHONE, FX.AREA_CODE, "123456")
 
-    assert p["mobile"] == f"APP-LOGIN@{FX.PHONE}_{FX.AREA_CODE}"
+    assert p["mobile"] == f"APP-LOGIN@{FX.AREA_CODE}_{FX.PHONE}"
     assert p["grant_type"] == "mobile"
     assert p["loginType"] == "mobile"
     assert p["code"] != "123456", "il codice deve essere cifrato SM4, non in chiaro"

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -69,28 +69,44 @@ def test_email_malformata_non_esce_mai(valore):
 # ───────────────────────── identità composita ─────────────────────────
 
 def test_identita_tiene_la_forma_e_butta_il_numero():
-    """La forma `APP-LOGIN@<num>_<area>` è ciò che si sta verificando quando si legge un log
-    di login: va conservata, il numero no."""
-    assert mask.identita_mobile("APP-LOGIN@3001234567_39") == "APP-LOGIN@***4567_39"  # PHONE_PLACEHOLDER
+    """La forma `APP-LOGIN@<prefisso>_<numero>` è ciò che si sta verificando quando si legge un
+    log di login: la si conserva, il numero no. Ordine confermato nel decompilato
+    (`UserService::phoneVerifyLogin` costruisce `APP-LOGIN@{areaCode}_{number}`)."""
+    assert mask.identita_mobile("APP-LOGIN@39_3001234567") == "APP-LOGIN@39_***4567"  # PHONE_PLACEHOLDER
 
 def test_identita_di_forma_inattesa_non_tira_a_indovinare():
-    assert mask.identita_mobile("3001234567") == "***4567"            # PHONE_PLACEHOLDER
-    assert mask.identita_mobile("APP-LOGIN@12_39") == "APP-LOGIN@***_39"  # PHONE_PLACEHOLDER
+    assert mask.identita_mobile("3001234567") == "***4567"               # PHONE_PLACEHOLDER
+    assert mask.identita_mobile("APP-LOGIN@39_12") == "APP-LOGIN@39_***"  # numero troppo corto -> ***  # PHONE_PLACEHOLDER
     assert mask.identita_mobile("") == mask.OSCURATO
+
+def test_identita_maschera_il_primo_campo_se_non_e_un_prefisso():
+    """Regressione (feedback di Rino): rendere la mascheratura posizionale — stampare SEMPRE il
+    primo campo — faceva uscire il dominio di un ingresso malformato `mario@rossi.it_39` come
+    `rossi.it_***`. Il primo campo si ristampa solo se è un vero prefisso di chiamata (1–3
+    cifre); un dominio, un nome o un numero finito lì per errore vengono mascherati. L'unico
+    verso in cui si può sbagliare è mascherare troppo."""
+    assert mask.identita_mobile("mario@rossi.it_39") == "***_***"
+    assert "rossi.it" not in mask.identita_mobile("mario@rossi.it_39")
+    # numero intero finito per errore nel PRIMO campo (ordine invertito): non deve uscire intero
+    assert "3001234567" not in mask.identita_mobile("APP-LOGIN@3001234567_39")  # PHONE_PLACEHOLDER
+    # un prefisso vero (1–3 cifre) invece SÌ resta leggibile, è la forma che si sta verificando
+    assert mask.identita_mobile("APP-LOGIN@393_3001234567") == "APP-LOGIN@393_***4567"  # PHONE_PLACEHOLDER
 
 
 # ──────────────────── le due copie del pattern e-mail ────────────────────
 
 @pytest.mark.parametrize("ingresso,vietato", [
     ("mario@rossi.it_39", "mario"),      # la «testa» non è il modulo: non va ristampata
+    ("mario@rossi.it_39", "rossi.it"),   # e nemmeno il dominio: era una regressione (primo campo in chiaro)
     ("A@B@C_39", "B"),                   # chiocciole multiple
     ("mario.rossi@example.com", "mario"),
+    ("APP-LOGIN@3001234567_39", "3001234567"),  # ordine invertito: il numero intero non deve uscire  # PHONE_PLACEHOLDER
 ])
 def test_identita_non_ristampa_una_testa_che_non_e_il_modulo(ingresso, vietato):
     """`rpartition('@')` da sola non verifica NULLA: prendeva per «modulo» qualunque cosa
     precedesse l'ultima chiocciola e la ristampava in chiaro. Con un valore che arriva grezzo
     dall'ambiente (`OMODA_PHONE` non passa dalla normalizzazione del config flow) usciva un
-    indirizzo intero."""
+    indirizzo intero. Stesso principio sul PRIMO campo del corpo: non è un prefisso ⇒ mascherato."""
     assert vietato not in mask.identita_mobile(ingresso)
 
 

--- a/tests/test_normalizza_telefono.py
+++ b/tests/test_normalizza_telefono.py
@@ -2,7 +2,7 @@
 
 Perché questo file esiste. Quella funzione è dichiarata dal codice stesso come l'unico
 passaggio di pulizia: «da qui in poi viaggiano in entry.data, nell'ambiente dei sottoprocessi
-e nell'identità `APP-LOGIN@<num>_<area>`, e a valle nessuno li tocca più». Non aveva un solo
+e nell'identità `APP-LOGIN@<area>_<num>`, e a valle nessuno li tocca più». Non aveva un solo
 test, e conteneva tre difetti che la suite non poteva vedere perché l'unico numero usato dai
 fixture è proprio quello che la funzione trattava bene:
 


### PR DESCRIPTION
Fixes #5

Two related fixes to the SMS/mobile login experience.

## 1. Correct the SMS-login composite identity order

Mobile (SMS) login built the OAuth identity as `APP-LOGIN@<number>_<areaCode>`, but the backend
expects `APP-LOGIN@<areaCode>_<number>`. Reversed, the token was minted against a **phantom**
account (a user record with `areaCode`/`phone` swapped, no vehicles, no TSP user) instead of the
caller's real account — so `getTuserId` returned `"0"` and `login` returned `app.service.failed`,
and **every** SMS login failed at vehicle discovery even though OTP send and token mint succeeded.

Verified live by comparing email and SMS logins of the same account: the corrected order resolves
to the real account (same `tUserId` and vehicle as the email login); the old order resolved to the
empty phantom. Also updates `mask.identita_mobile` to redact the **second** field (the number)
rather than the first — with the corrected order the first field is only the dialling prefix, so
the old masking would have leaked the number into logs.

## 2. Show "no vehicle" instead of "invalid OTP" when the code was valid

When the OTP is correct and the token mints, but the account has **no vehicle**, the post-mint
login check fails and `async_step_otp` used to label it **"invalid OTP code"** — sending users to
re-check a code that was fine. The usual trigger is signing into the **wrong account** (e.g. the
phone number when the car is on the email login).

`async_step_otp` now routes on whether a token was **actually minted** (`_pending_token_minted`):
if one was written it proceeds to discovery, which correctly reports **`no_vehicle`**; only a
genuinely rejected code shows `otp_invalid`. The `no_vehicle` message now hints to sign in with the
other login (e.g. email). Translations updated (en / it / strings).

No behaviour change for email login; existing entries unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
