### PR TITLE
Add English/Italian language selector

### DIFF
--- a/custom_components/omoda9/config_flow.py
+++ b/custom_components/omoda9/config_flow.py
@@ -23,6 +23,10 @@ from homeassistant import config_entries
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.helpers.selector import (
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
     TextSelector,
     TextSelectorConfig,
     TextSelectorType,
@@ -31,6 +35,7 @@ from homeassistant.helpers.selector import (
 from .const import (
     DOMAIN, CONF_EMAIL, CONF_PIN, CONF_VIN, CONF_TUSERID,
     CONF_PHONE, CONF_AREA_CODE, DEFAULT_AREA_CODE,
+    CONF_LANGUAGE, DEFAULT_LANGUAGE, LANGUAGES,
     CONF_BFF, CONF_TSP_HOST, CONF_CERTS_SRC, CONF_CHANNEL_ID,
     CONF_CAR_MQTT_HOST, CONF_CAR_MQTT_PORT, DEFAULTS,
     CONF_POLL_NORMAL, CONF_POLL_CHARGING,
@@ -247,6 +252,8 @@ def _ctx_del_flow(hass: HomeAssistant, data: dict, token_path: str | None = None
         tsp_host=data.get(CONF_TSP_HOST, DEFAULTS[CONF_TSP_HOST]),
         bff=data.get(CONF_BFF, DEFAULTS[CONF_BFF]),
         channel_id=str(data.get(CONF_CHANNEL_ID, DEFAULTS[CONF_CHANNEL_ID])),
+        # lingua (Accept-Language) scelta al login → e-mail/SMS OTP nella lingua giusta
+        language=str(data.get(CONF_LANGUAGE, DEFAULT_LANGUAGE) or DEFAULT_LANGUAGE),
     )
 
 
@@ -340,8 +347,16 @@ class Omoda9ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return Omoda9OptionsFlow(config_entry)
 
     def _region_fields(self) -> dict:
-        """Campi opzionali di REGIONE, comuni a login email e telefono (default = Europa)."""
+        """Campi opzionali di REGIONE/LINGUA, comuni a login email e telefono (default = Europa)."""
         return {
+            # Lingua delle chiamate (Accept-Language): decide la lingua di e-mail/SMS OTP e dei
+            # messaggi del server. Nuovi account: inglese; si può scegliere l'italiano.
+            vol.Optional(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): SelectSelector(
+                SelectSelectorConfig(
+                    mode=SelectSelectorMode.DROPDOWN,
+                    options=[SelectOptionDict(value=v, label=lbl) for v, lbl in LANGUAGES.items()],
+                )
+            ),
             # Solo per regioni diverse dall'Europa / setup avanzato (default EU).
             vol.Optional(CONF_BFF, default=DEFAULTS[CONF_BFF]): str,
             vol.Optional(CONF_TSP_HOST, default=DEFAULTS[CONF_TSP_HOST]): str,

--- a/custom_components/omoda9/const.py
+++ b/custom_components/omoda9/const.py
@@ -59,6 +59,17 @@ CONF_PHONE = "phone"
 CONF_AREA_CODE = "area_code"     # prefisso internazionale in sole cifre (Italia = 39)
 DEFAULT_AREA_CODE = "39"
 
+# Lingua delle chiamate al backend: guida l'header `Accept-Language`, che a sua volta decide la
+# lingua di e-mail OTP, SMS e messaggi del server (il backend non ha un parametro `lang` sul
+# codice: comanda l'header). Il valore memorizzato È il valore dell'header (`en-GB`/`it-IT`).
+#   * setup ESISTENTI (nessun campo `language`) → `LANGUAGE_FALLBACK` = it-IT: comportamento
+#     storico invariato;
+#   * setup NUOVI → il dropdown parte da `DEFAULT_LANGUAGE` = en-GB (questo fork è in inglese).
+CONF_LANGUAGE = "language"
+DEFAULT_LANGUAGE = "en-GB"       # default del dropdown per i NUOVI account
+LANGUAGE_FALLBACK = "it-IT"      # entry senza il campo → comportamento storico
+LANGUAGES = {"en-GB": "English", "it-IT": "Italiano"}   # valore-header → etichetta del dropdown
+
 # Identità veicolo per il device HA (nome dinamico: "Omoda 9", "Jaecoo 7"…). `vehicle_name`
 # = nickname/modello dall'app, salvato in entry.data (catturato al config flow o backfillato);
 # è anche un'OPZIONE per l'override manuale. model/brand restano solo in entry.data.

--- a/custom_components/omoda9/coordinator.py
+++ b/custom_components/omoda9/coordinator.py
@@ -34,6 +34,7 @@ from .const import (
     DOMAIN, CAR_SEED, DEFAULT_AWAKE_WINDOW, DEFAULT_SESSION_EVERY, CERT_FILES,
     CONF_VIN, CONF_TUSERID, CONF_PIN, CONF_EMAIL, CONF_CERTS_SRC,
     CONF_PHONE, CONF_AREA_CODE, DEFAULT_AREA_CODE,
+    CONF_LANGUAGE, LANGUAGE_FALLBACK,
     CONF_BFF, CONF_TSP_HOST, CONF_CAR_MQTT_HOST, CONF_CAR_MQTT_PORT, CONF_CHANNEL_ID,
     CONF_POLL_NORMAL, CONF_POLL_CHARGING, DEFAULT_POLL_NORMAL_MIN,
     DEFAULT_POLL_CHARGING_MIN, POLL_WAKE_WAIT, COMMAND_SETTLE_S, COMMAND_QUEUE_WAIT,
@@ -277,6 +278,8 @@ class Omoda9Coordinator(DataUpdateCoordinator):
         # riautenticazione userà il ramo mobile. area_code = prefisso in cifre.
         self.phone = cfg.get(CONF_PHONE, "")
         self.area_code = str(cfg.get(CONF_AREA_CODE, DEFAULT_AREA_CODE) or DEFAULT_AREA_CODE)
+        # lingua (Accept-Language): assente negli entry esistenti → it-IT (comportamento storico)
+        self.language = str(cfg.get(CONF_LANGUAGE) or LANGUAGE_FALLBACK)
 
         # identità veicolo per il device HA. Priorità: override manuale (opzioni) →
         # valore salvato in entry.data (config flow / backfill) → None (→ fallback in entity.py).
@@ -1052,6 +1055,7 @@ class Omoda9Coordinator(DataUpdateCoordinator):
             email=self.email,
             phone=self.phone,
             area_code=self.area_code,
+            language=self.language,
             token_path=self.token_path,
             # taskId nella config dir per-VIN: sopravvive agli update HACS e non è
             # condiviso fra veicoli.

--- a/custom_components/omoda9/core/context.py
+++ b/custom_components/omoda9/core/context.py
@@ -116,6 +116,10 @@ class CoreCtx:
     channel_id: str = DEFAULT_CHANNEL_ID
     country_id: str = DEFAULT_COUNTRY_ID
     tenant_code: str = DEFAULT_TENANT_CODE
+    # Lingua delle chiamate (header `Accept-Language`): decide la lingua di e-mail OTP/SMS/messaggi
+    # del server. Valore = valore dell'header. Default it-IT = comportamento storico per gli entry
+    # che non lo impostano.
+    language: str = "it-IT"
 
     # — comportamento —
     # conio automatico del taskId: senza, i comandi non possono partire (serve un
@@ -207,5 +211,6 @@ def ctx_da_environ() -> CoreCtx:
         channel_id=os.environ.get("CHANNEL_ID", DEFAULT_CHANNEL_ID),
         country_id=os.environ.get("OMODA_COUNTRY_ID", DEFAULT_COUNTRY_ID),
         tenant_code=os.environ.get("OMODA_TENANT_CODE", DEFAULT_TENANT_CODE),
+        language=os.environ.get("OMODA_LANGUAGE", "it-IT"),
         mint_taskid=os.environ.get("OMODA_MINT_TASKID", "1") not in ("0", "", "false", "no"),
     )

--- a/custom_components/omoda9/core/login_omoda.py
+++ b/custom_components/omoda9/core/login_omoda.py
@@ -37,6 +37,9 @@ def _motivo(testo):
 BFF = os.environ.get("OMODA_BFF", "https://legend-oj.omodaauto.nl/api")   # regione (default EU)
 SECRET = "5c7af05e6fbf562842ef483ee96e06a0"
 NONCE = "chery_legend_marketing"
+# Lingua dell'invio OTP (header Accept-Language) → lingua di e-mail/SMS del codice. Default it-IT
+# (comportamento storico); il coordinator/config_flow passa `OMODA_LANGUAGE` nell'ambiente.
+ACCEPT_LANGUAGE = os.environ.get("OMODA_LANGUAGE", "it-IT")
 def _md5(s): return hashlib.md5(s.encode()).hexdigest()
 
 # L'invio SMS (`sendSmsCode`) è l'UNICO endpoint dietro il WAF Aliyun, che filtra
@@ -54,7 +57,7 @@ def _hdr_form(path):
             "TENANT-CODE": omoda.TENANT_CODE, "TENANT-ID": omoda.TENANT_CODE,
             "tenantCode": omoda.TENANT_CODE, "tenantID": omoda.TENANT_CODE, "tenant": omoda.TENANT_CODE,
             "channelId": omoda.CHANNEL_ID, "countryId": omoda.COUNTRY_ID,
-            "appversion": omoda.APP_VERSION, "User-Agent": "okhttp/4.9.0", "Accept-Language": "it-IT",
+            "appversion": omoda.APP_VERSION, "User-Agent": "okhttp/4.9.0", "Accept-Language": ACCEPT_LANGUAGE,
             "nonce": NONCE, "timestamp": str(ts), "url": path,
             "signature": _md5(f"{SECRET}{NONCE}{path}{ts}"),
             "Content-Type": "application/x-www-form-urlencoded"}
@@ -158,7 +161,7 @@ def _token_headers(path, params):
             "TENANT-CODE": omoda.TENANT_CODE, "TENANT-ID": omoda.TENANT_CODE,
             "tenantCode": omoda.TENANT_CODE, "tenantID": omoda.TENANT_CODE, "tenant": omoda.TENANT_CODE,
             "channelId": omoda.CHANNEL_ID, "countryId": omoda.COUNTRY_ID,
-            "appversion": omoda.APP_VERSION, "Accept-Language": "it-IT",
+            "appversion": omoda.APP_VERSION, "Accept-Language": ACCEPT_LANGUAGE,
             "nonce": NONCE, "timestamp": str(ts), "url": path, "keys": ",".join(keys),
             "signature": _md5(f"{SECRET}{NONCE}{path}{ts}[{vals_csv}]")}
 

--- a/custom_components/omoda9/core/omoda_auth.py
+++ b/custom_components/omoda9/core/omoda_auth.py
@@ -35,6 +35,9 @@ BFF          = os.environ.get("OMODA_BFF", "https://legend-oj.omodaauto.nl/api")
 TENANT_CODE  = os.environ.get("OMODA_TENANT_CODE", "300006")
 CHANNEL_ID   = os.environ.get("CHANNEL_ID", "1")
 COUNTRY_ID   = os.environ.get("OMODA_COUNTRY_ID", "1")
+# Lingua delle chiamate (header Accept-Language): decide la lingua di e-mail OTP/SMS/messaggi
+# server. Default it-IT (comportamento storico). Con `ctx` si usa `ctx.language`.
+ACCEPT_LANGUAGE = os.environ.get("OMODA_LANGUAGE", "it-IT")
 
 SIGN_NONCE   = "chery_legend_h5"                       # headerSignature nonce
 SIGN_SECRET  = "cX5fR8lJ6pK2xD4uH1eK4pY6wA4xO0sK"     # prod (ENV=0)
@@ -129,6 +132,7 @@ def headers_post(url_path: str, secret: str=SIGN_SECRET, nonce: str=SIGN_NONCE,
     channel_id = ctx.channel_id if ctx is not None else CHANNEL_ID
     country_id = ctx.country_id if ctx is not None else COUNTRY_ID
     tenant = ctx.tenant_code if ctx is not None else TENANT_CODE
+    accept_lang = getattr(ctx, "language", None) or ACCEPT_LANGUAGE if ctx is not None else ACCEPT_LANGUAGE
     # `DEPT-ID` è, per ammissione della mappa da cui è stato estratto, il PREFISSO del Paese:
     # Italia 39, Francia 33, Germania 49. Con l'arrivo del login via SMS il prefisso è
     # diventato un dato che l'utente sceglie, e restava scollegato da qui: a un tedesco si
@@ -148,7 +152,7 @@ def headers_post(url_path: str, secret: str=SIGN_SECRET, nonce: str=SIGN_NONCE,
     h = {
         "Accept": "application/json, text/plain, */*",
         "Content-Type": "application/x-www-form-urlencoded",
-        "Accept-Language": "it-IT",
+        "Accept-Language": accept_lang,
         "Accept-Encoding": "gzip, deflate",
         "agent": "android",
         "version": APP_VERSION,

--- a/custom_components/omoda9/core/session.py
+++ b/custom_components/omoda9/core/session.py
@@ -161,6 +161,7 @@ def _subenv(ctx, **extra):
         "CHANNEL_ID": ctx.channel_id,
         "OMODA_COUNTRY_ID": ctx.country_id,
         "OMODA_TENANT_CODE": ctx.tenant_code,
+        "OMODA_LANGUAGE": getattr(ctx, "language", "it-IT") or "it-IT",
         "VIN": ctx.vin,
         "TUSERID": ctx.tuserid,
     })

--- a/custom_components/omoda9/strings.json
+++ b/custom_components/omoda9/strings.json
@@ -15,6 +15,7 @@
         "data": {
           "email": "Account email",
           "pin": "Vehicle control PIN",
+          "language": "Language (OTP emails / SMS)",
           "bff": "BFF endpoint (region)",
           "tsp_host": "TSP console host (region)",
           "car_mqtt_host": "Vehicle MQTT broker host (region)",
@@ -30,6 +31,7 @@
           "phone": "Phone number (without country code)",
           "area_code": "Country code in digits (e.g. 39)",
           "pin": "Vehicle control PIN",
+          "language": "Language (OTP emails / SMS)",
           "bff": "BFF endpoint (region)",
           "tsp_host": "TSP console host (region)",
           "car_mqtt_host": "Vehicle MQTT broker host (region)",

--- a/custom_components/omoda9/translations/en.json
+++ b/custom_components/omoda9/translations/en.json
@@ -15,6 +15,7 @@
         "data": {
           "email": "Account email",
           "pin": "Vehicle control PIN",
+          "language": "Language (OTP emails / SMS)",
           "bff": "BFF endpoint (region)",
           "tsp_host": "TSP console host (region)",
           "car_mqtt_host": "Vehicle MQTT broker host (region)",
@@ -30,6 +31,7 @@
           "phone": "Phone number (without country code)",
           "area_code": "Country code in digits (e.g. 39)",
           "pin": "Vehicle control PIN",
+          "language": "Language (OTP emails / SMS)",
           "bff": "BFF endpoint (region)",
           "tsp_host": "TSP console host (region)",
           "car_mqtt_host": "Vehicle MQTT broker host (region)",

--- a/custom_components/omoda9/translations/it.json
+++ b/custom_components/omoda9/translations/it.json
@@ -15,6 +15,7 @@
         "data": {
           "email": "Email dell'account",
           "pin": "PIN di controllo veicolo",
+          "language": "Lingua (e-mail / SMS OTP)",
           "bff": "Endpoint BFF (regione)",
           "tsp_host": "Host console TSP (regione)",
           "car_mqtt_host": "Host broker MQTT del veicolo (regione)",
@@ -30,6 +31,7 @@
           "phone": "Numero di telefono (senza prefisso)",
           "area_code": "Prefisso internazionale in cifre (es. 39)",
           "pin": "PIN di controllo veicolo",
+          "language": "Lingua (e-mail / SMS OTP)",
           "bff": "Endpoint BFF (regione)",
           "tsp_host": "Host console TSP (regione)",
           "car_mqtt_host": "Host broker MQTT del veicolo (regione)",

--- a/tests/test_capabilities_scheda.py
+++ b/tests/test_capabilities_scheda.py
@@ -321,6 +321,7 @@ def test_il_contesto_non_riceve_capability_inventate(tmp_path):
     c.email, c.phone, c.area_code = "x@y.z", "", "39"
     c.token_path = str(tmp_path / "token.json")
     c.tsp_host, c.bff, c.channel_id = "https://tsp.invalid", "https://bff.invalid", "1"
+    c.language = "en-GB"   # il selettore lingua aggiunge ctx.language: il finto coordinator lo deve avere
     c.hass = type("H", (), {"config": type("Cf", (), {"path": staticmethod(str)})()})()
     for nome in ("climate_limits", "climate_extremes", "air_durations", "_caps_correnti"):
         setattr(c, nome, (lambda n: lambda: getattr(Omoda9Coordinator, n)(c))(nome))


### PR DESCRIPTION
Closes #15

Adds a **language dropdown** to the setup form. It sets the `Accept-Language` header on the
backend calls, which is what decides the language of **OTP emails, SMS and server-returned
messages** — the code endpoints have no `lang` parameter, so the header is the lever.

### Behaviour
- New option in the setup form: **Language (OTP emails / SMS)** — English or Italian, easy to
  extend later.
- **New setups default to English** (`en-GB`).
- **Existing setups are unchanged:** entries without the field (and any internal call without a
  context) fall back to `it-IT`, exactly as today.

### Changes
- `const.py`: `CONF_LANGUAGE`, `LANGUAGES` (`en-GB`/`it-IT`), `DEFAULT_LANGUAGE`, `LANGUAGE_FALLBACK`.
- `core/context.py`: `CoreCtx.language` (+ `OMODA_LANGUAGE` in `ctx_da_environ`).
- `core/omoda_auth.py`: `headers_post` uses the context language.
- `core/login_omoda.py`: OTP-send headers (email **and** SMS) use the chosen language.
- `core/session.py`: `_subenv` forwards `OMODA_LANGUAGE` to the login subprocess.
- `coordinator.py`: reads `CONF_LANGUAGE` and threads it into the context.
- `config_flow.py`: the dropdown in the region fields.
- translations (en / it / strings).

Verified locally: `Accept-Language` follows the selected language; ctx-less calls and entries
without the field stay on `it-IT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
