### PR TITLE
Show "no vehicle" instead of "invalid OTP" when the code was valid

### DIFF
--- a/custom_components/omoda9/config_flow.py
+++ b/custom_components/omoda9/config_flow.py
@@ -64,6 +64,22 @@ def _pending_token_path(hass: HomeAssistant) -> str:
     return hass.config.path(f"{DOMAIN}_pending_token.json")
 
 
+def _pending_token_minted(hass: HomeAssistant) -> bool:
+    """True se un token è stato davvero SCRITTO (OTP valido), anche quando `confirm_otp` ha poi
+    riportato un fallimento perché il login post-conio non è riuscito — di norma perché l'account
+    NON ha veicoli. Serve a distinguere «codice sbagliato» (nessun token) da «codice giusto ma
+    niente auto sull'account»: il primo è `otp_invalid`, il secondo `no_vehicle`, e finché non li
+    si separava un login sull'account sbagliato usciva come «OTP non valido», mandando l'utente a
+    ricontrollare all'infinito un codice che era corretto."""
+    try:
+        with open(_pending_token_path(hass), encoding="utf-8") as fh:
+            tok = json.load(fh)
+    except Exception:  # noqa: BLE001
+        return False
+    d = tok.get("data", tok) if isinstance(tok, dict) else {}
+    return bool(d.get("access_token") if isinstance(d, dict) else None)
+
+
 def _reason_line(detail: str | None) -> str:
     """Riga col motivo del fallimento, mostrata sotto il form (vuota se non c'è). Il dettaglio è
     la coda dell'output del sottoprocesso di login (stato HTTP / chiave del server tipo
@@ -428,7 +444,13 @@ class Omoda9ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             ok, msg = await self.hass.async_add_executor_job(
                 _mint_token, self.hass, self._data, user_input["code"].strip()
             )
-            if ok:
+            # Anche se `confirm_otp` riporta KO, il token può ESSERE stato coniato (OTP valido):
+            # a fallire è allora il login post-conio, di norma perché l'account non ha veicoli.
+            # Distinguo i due casi dal fatto che un token sia stato scritto, così un login
+            # sull'account sbagliato non esce più come «OTP non valido».
+            minted = ok or await self.hass.async_add_executor_job(
+                _pending_token_minted, self.hass)
+            if minted:
                 d_ok, tu, vins, detail = await self.hass.async_add_executor_job(
                     _discover, self.hass, self._data
                 )
@@ -445,7 +467,7 @@ class Omoda9ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         return await self._create_entry(vins[0])
                     return await self.async_step_select_vehicle()
             else:
-                # OTP errato/scaduto: butta il pending eventualmente già scritto.
+                # Nessun token scritto → il CODICE è stato davvero rifiutato (errato/scaduto).
                 await self.hass.async_add_executor_job(_cleanup_pending, self.hass)
                 errors["base"] = "otp_invalid"
                 reason = _reason_line(msg)

--- a/custom_components/omoda9/strings.json
+++ b/custom_components/omoda9/strings.json
@@ -103,7 +103,7 @@
     "error": {
       "otp_send_failed": "Could not send the code. Check the email/phone and PIN and try again.",
       "otp_invalid": "Invalid or expired OTP code.",
-      "no_vehicle": "Login succeeded but no vehicle was found on this account.",
+      "no_vehicle": "Signed in, but this account has no vehicles. If your car is registered under a different login (e.g. your email address), sign in with that one instead.",
       "pin_required": "Enter the vehicle control PIN.",
       "otp_required": "Enter the code you received.",
       "phone_invalid": "That phone number does not look right. Enter the digits of the number only, without the country code and without spaces; in the other field put only the digits of the country code (Italy = 39).",

--- a/custom_components/omoda9/translations/en.json
+++ b/custom_components/omoda9/translations/en.json
@@ -103,7 +103,7 @@
     "error": {
       "otp_send_failed": "Could not send the code. Check the email/phone and PIN and try again.",
       "otp_invalid": "Invalid or expired OTP code.",
-      "no_vehicle": "Login succeeded but no vehicle was found on this account.",
+      "no_vehicle": "Signed in, but this account has no vehicles. If your car is registered under a different login (e.g. your email address), sign in with that one instead.",
       "pin_required": "Enter the vehicle control PIN.",
       "otp_required": "Enter the code you received.",
       "phone_invalid": "That phone number does not look right. Enter the digits of the number only, without the country code and without spaces; in the other field put only the digits of the country code (Italy = 39).",

--- a/custom_components/omoda9/translations/it.json
+++ b/custom_components/omoda9/translations/it.json
@@ -103,7 +103,7 @@
     "error": {
       "otp_send_failed": "Impossibile inviare il codice. Controlla email/telefono e PIN e riprova.",
       "otp_invalid": "Codice OTP non valido o scaduto.",
-      "no_vehicle": "Login riuscito ma nessun veicolo trovato su questo account.",
+      "no_vehicle": "Accesso riuscito, ma questo account non ha veicoli. Se l'auto è registrata su un altro accesso (es. la tua e-mail), usa quello.",
       "pin_required": "Inserisci il PIN di controllo veicolo.",
       "otp_required": "Inserisci il codice che hai ricevuto.",
       "phone_invalid": "Questo numero non sembra giusto. Scrivi solo le cifre del numero, senza prefisso internazionale e senza spazi; nell'altro campo metti solo le cifre del prefisso (Italia = 39).",


### PR DESCRIPTION
When the OTP code is **correct** and the token mints, but the account has **no vehicle**, the
config flow was showing **"invalid OTP code"** — sending people to re-check a code that was fine.

The post-mint login check fails for a car-less account (no TSP user), `confirm_otp` reports
failure, and `async_step_otp` mapped *any* failure to `otp_invalid`. The most common way to hit
this is signing into the **wrong account** — e.g. logging in with the phone number when the car
is registered on the email login.

### Fix
- `async_step_otp` now routes on whether a token was **actually minted** (`_pending_token_minted`):
  if a token was written, it proceeds to vehicle discovery, which correctly reports **`no_vehicle`**;
  only a genuinely rejected code (no token) shows `otp_invalid`.
- The `no_vehicle` message now hints to try the other login: *"…this account has no vehicles. If
  your car is registered under a different login (e.g. your email address), sign in with that one."*
- Translations updated (en / it / strings).

Related to #5 — this is exactly the confusing failure a phone-only user hits when their car is on
a different (email) account. Independent of the SMS identity fix (#14); own branch off `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
