### PR TITLE
Add Omoda/Jaecoo vs Chery region presets

### DIFF
--- a/custom_components/omoda9/config_flow.py
+++ b/custom_components/omoda9/config_flow.py
@@ -23,6 +23,10 @@ from homeassistant import config_entries
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.helpers.selector import (
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
     TextSelector,
     TextSelectorConfig,
     TextSelectorType,
@@ -33,6 +37,9 @@ from .const import (
     CONF_PHONE, CONF_AREA_CODE, DEFAULT_AREA_CODE,
     CONF_BFF, CONF_TSP_HOST, CONF_CERTS_SRC, CONF_CHANNEL_ID,
     CONF_CAR_MQTT_HOST, CONF_CAR_MQTT_PORT, DEFAULTS,
+    CONF_TENANT_CODE, CONF_COUNTRY_ID,
+    CONF_PRESET, PRESETS, DEFAULT_PRESET,
+    PRESET_OMODA_JAECOO_EU, PRESET_CHERY_EU, PRESET_CUSTOM,
     CONF_POLL_NORMAL, CONF_POLL_CHARGING,
     DEFAULT_POLL_NORMAL_MIN, DEFAULT_POLL_CHARGING_MIN,
     CONF_VEHICLE_NAME,
@@ -247,6 +254,10 @@ def _ctx_del_flow(hass: HomeAssistant, data: dict, token_path: str | None = None
         tsp_host=data.get(CONF_TSP_HOST, DEFAULTS[CONF_TSP_HOST]),
         bff=data.get(CONF_BFF, DEFAULTS[CONF_BFF]),
         channel_id=str(data.get(CONF_CHANNEL_ID, DEFAULTS[CONF_CHANNEL_ID])),
+        # tenant/countryId per-marchio: senza questi il login e la queryList partivano
+        # sempre col tenant Omoda (300006), quindi un account Chery non veniva riconosciuto.
+        tenant_code=str(data.get(CONF_TENANT_CODE, DEFAULTS[CONF_TENANT_CODE])),
+        country_id=str(data.get(CONF_COUNTRY_ID, DEFAULTS[CONF_COUNTRY_ID])),
     )
 
 
@@ -340,18 +351,50 @@ class Omoda9ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return Omoda9OptionsFlow(config_entry)
 
     def _region_fields(self) -> dict:
-        """Campi opzionali di REGIONE, comuni a login email e telefono (default = Europa)."""
+        """Campi opzionali di REGIONE/MARCHIO, comuni a login email e telefono.
+
+        Il preset è la scelta normale: «Omoda / Jaecoo (Europa)» (default, comportamento
+        storico) o «Chery (Europa)». Riempie da solo BFF + TENANT-CODE + channelId + countryId.
+        I campi sotto servono a chi sta su un'altra regione/marchio: si sceglie «Custom» e li si
+        compila a mano. TSP host, broker MQTT e certificati sono comuni per regione (EU di
+        default) e restano validi per entrambi i marchi."""
         return {
-            # Solo per regioni diverse dall'Europa / setup avanzato (default EU).
+            vol.Optional(CONF_PRESET, default=DEFAULT_PRESET): SelectSelector(
+                SelectSelectorConfig(
+                    mode=SelectSelectorMode.DROPDOWN,
+                    options=[
+                        SelectOptionDict(value=PRESET_OMODA_JAECOO_EU,
+                                         label="Omoda / Jaecoo — Europe"),
+                        SelectOptionDict(value=PRESET_CHERY_EU,
+                                         label="Chery — Europe"),
+                        SelectOptionDict(value=PRESET_CUSTOM,
+                                         label="Custom / other region (use the fields below)"),
+                    ],
+                )
+            ),
+            # Valori riempiti dal preset (tranne «Custom»). Restano modificabili per le
+            # regioni/marchi non coperti da un preset.
             vol.Optional(CONF_BFF, default=DEFAULTS[CONF_BFF]): str,
+            vol.Optional(CONF_TENANT_CODE, default=DEFAULTS[CONF_TENANT_CODE]): str,
+            vol.Optional(CONF_COUNTRY_ID, default=DEFAULTS[CONF_COUNTRY_ID]): str,
+            vol.Optional(CONF_CHANNEL_ID, default=DEFAULTS[CONF_CHANNEL_ID]): str,
+            # Comuni per regione (default EU): un setup non-EU li cambia insieme al resto.
             vol.Optional(CONF_TSP_HOST, default=DEFAULTS[CONF_TSP_HOST]): str,
-            # Broker MQTT dell'auto + channel id: regione-specifici (default EU). Senza
-            # questi campi un setup non-EU resterebbe agganciato al broker europeo.
             vol.Optional(CONF_CAR_MQTT_HOST, default=DEFAULTS[CONF_CAR_MQTT_HOST]): str,
             vol.Optional(CONF_CAR_MQTT_PORT, default=DEFAULTS[CONF_CAR_MQTT_PORT]): vol.Coerce(int),
-            vol.Optional(CONF_CHANNEL_ID, default=DEFAULTS[CONF_CHANNEL_ID]): str,
             vol.Optional(CONF_CERTS_SRC, default=""): str,
         }
+
+    @staticmethod
+    def _apply_preset(data: dict) -> None:
+        """Se è selezionato un preset di marchio, i suoi valori di regione VINCONO sui campi
+        digitati (BFF/TENANT-CODE/channelId/countryId). «Custom» non tocca nulla: valgono i
+        campi così come li ha lasciati l'utente. Il preset viene poi rimosso dai dati salvati:
+        è una comodità del form, non un parametro che `core/` conosca."""
+        preset = data.pop(CONF_PRESET, DEFAULT_PRESET)
+        values = PRESETS.get(preset)
+        if values:
+            data.update(values)
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None):
         """Scelta del metodo di accesso: e-mail oppure numero di telefono (SMS).
@@ -366,6 +409,9 @@ class Omoda9ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def _submit_login(self, user_input: dict[str, Any], step_id: str, schema):
         """Logica comune ai due login: salva i dati, prova a inviare l'OTP, va allo step OTP."""
         self._data.update(user_input)
+        # Preset di marchio → risolve BFF/TENANT-CODE/channelId/countryId prima di coniare il
+        # token: il primo login deve già partire verso il gateway/tenant giusto.
+        self._apply_preset(self._data)
         ok, msg = await self.hass.async_add_executor_job(_send_otp, self.hass, self._data)
         if ok:
             return await self.async_step_otp()

--- a/custom_components/omoda9/const.py
+++ b/custom_components/omoda9/const.py
@@ -195,6 +195,12 @@ CONF_TSP_HOST = "tsp_host"
 CONF_CAR_MQTT_HOST = "car_mqtt_host"
 CONF_CAR_MQTT_PORT = "car_mqtt_port"
 CONF_CHANNEL_ID = "channel_id"
+# TENANT-CODE e countryId: fin qui erano cablati ai valori Omoda/Jaecoo dentro `CoreCtx`
+# (300006 / 1) e non arrivavano dal config entry. Sono diversi PER MARCHIO sullo stesso
+# gateway "legend": senza esporli non si poteva puntare l'integrazione al tenant Chery
+# (300001 / 2). Ora fanno parte dei parametri di regione, valorizzati dai preset qui sotto.
+CONF_TENANT_CODE = "tenant_code"
+CONF_COUNTRY_ID = "country_id"
 
 # Provisioning certificati mutual-TLS MQTT (FASE 3c). Cartella (dentro il filesystem di HA)
 # da cui importare i 4 cert nella certs_dir per-entry. Vuoto = i cert si mettono a mano.
@@ -209,6 +215,36 @@ DEFAULTS = {
     CONF_CAR_MQTT_HOST: "tspemqx-app-eu.cheryinternational.com",
     CONF_CAR_MQTT_PORT: 8083,
     CONF_CHANNEL_ID: "1",
+    CONF_TENANT_CODE: "300006",
+    CONF_COUNTRY_ID: "1",
+}
+
+# ── Preset marchio/regione ───────────────────────────────────────────────────────────────
+# Chery International serve Omoda/Jaecoo e Chery dallo STESSO backend "legend": il broker MQTT,
+# la TSP console e i certificati mutual-TLS sono comuni per regione; a cambiare per marchio sono
+# solo il gateway BFF, il TENANT-CODE, il channelId e il countryId. I valori Chery EU sono stati
+# ricavati dall'app Chery EU ufficiale (`com.chery.eu.chery`, .env.prod), che è lo stesso
+# applicativo `chery_legend` da cui è nata questa integrazione. Scegliere un preset riempie quei
+# quattro campi; "custom" lascia intatto ciò che l'utente ha digitato (altre regioni/marchi).
+CONF_PRESET = "preset"
+PRESET_OMODA_JAECOO_EU = "omoda_jaecoo_eu"
+PRESET_CHERY_EU = "chery_eu"
+PRESET_CUSTOM = "custom"
+DEFAULT_PRESET = PRESET_OMODA_JAECOO_EU
+
+PRESETS = {
+    PRESET_OMODA_JAECOO_EU: {
+        CONF_BFF: "https://legend-oj.omodaauto.nl/api",
+        CONF_TENANT_CODE: "300006",
+        CONF_CHANNEL_ID: "1",
+        CONF_COUNTRY_ID: "1",
+    },
+    PRESET_CHERY_EU: {
+        CONF_BFF: "https://eu-chery.cheryinternational.com/api",
+        CONF_TENANT_CODE: "300001",
+        CONF_CHANNEL_ID: "2",
+        CONF_COUNTRY_ID: "2",
+    },
 }
 
 # Costante app condivisa (non un segreto utente): seed per derivare la password MQTT

--- a/custom_components/omoda9/coordinator.py
+++ b/custom_components/omoda9/coordinator.py
@@ -35,6 +35,7 @@ from .const import (
     CONF_VIN, CONF_TUSERID, CONF_PIN, CONF_EMAIL, CONF_CERTS_SRC,
     CONF_PHONE, CONF_AREA_CODE, DEFAULT_AREA_CODE,
     CONF_BFF, CONF_TSP_HOST, CONF_CAR_MQTT_HOST, CONF_CAR_MQTT_PORT, CONF_CHANNEL_ID,
+    CONF_TENANT_CODE, CONF_COUNTRY_ID,
     CONF_POLL_NORMAL, CONF_POLL_CHARGING, DEFAULT_POLL_NORMAL_MIN,
     DEFAULT_POLL_CHARGING_MIN, POLL_WAKE_WAIT, COMMAND_SETTLE_S, COMMAND_QUEUE_WAIT,
     HV_ON_POLL_EVERY, HV_ON_POLL_MAX,
@@ -272,6 +273,10 @@ class Omoda9Coordinator(DataUpdateCoordinator):
         self.tsp_host = cfg[CONF_TSP_HOST]
         self.pin = cfg.get(CONF_PIN, "")
         self.bff = cfg[CONF_BFF]
+        # tenant/countryId per-marchio (default = Omoda/Jaecoo). `cfg` parte da DEFAULTS, quindi
+        # gli entry esistenti (senza queste chiavi) restano sui valori storici.
+        self.tenant_code = str(cfg.get(CONF_TENANT_CODE, DEFAULTS[CONF_TENANT_CODE]))
+        self.country_id = str(cfg.get(CONF_COUNTRY_ID, DEFAULTS[CONF_COUNTRY_ID]))
         self.email = cfg.get(CONF_EMAIL, "")
         # login via SMS (alternativa all'email): se il telefono è valorizzato, la
         # riautenticazione userà il ramo mobile. area_code = prefisso in cifre.
@@ -1060,6 +1065,8 @@ class Omoda9Coordinator(DataUpdateCoordinator):
             tsp_host=self.tsp_host,
             bff=self.bff,
             channel_id=self.channel_id,
+            tenant_code=self.tenant_code,
+            country_id=self.country_id,
             mint_taskid=os.environ.get("OMODA_MINT_TASKID", "1") not in ("0", "", "false", "no"),
             # Capability della vettura con nomi NEUTRI: `core/` è autonomo e non importa nulla
             # dal package padre, quindi non può conoscere le chiavi `DATA_*` di const.py.

--- a/custom_components/omoda9/strings.json
+++ b/custom_components/omoda9/strings.json
@@ -13,29 +13,41 @@
         "title": "Sign in with email",
         "description": "Enter your Omoda/Jaecoo account email and vehicle PIN. An OTP code will be sent to your email; VIN and account ID are detected automatically.{reason}",
         "data": {
+          "preset": "Brand / region preset",
           "email": "Account email",
           "pin": "Vehicle control PIN",
           "bff": "BFF endpoint (region)",
+          "tenant_code": "Tenant code (advanced)",
+          "country_id": "Country ID (advanced)",
           "tsp_host": "TSP console host (region)",
           "car_mqtt_host": "Vehicle MQTT broker host (region)",
           "car_mqtt_port": "Vehicle MQTT broker port (region)",
           "channel_id": "Channel ID (region)",
           "certs_src": "Folder with mutual-TLS certs to import (optional)"
+        },
+        "data_description": {
+          "preset": "Omoda/Jaecoo (Europe) and Chery (Europe) fill in everything automatically. Choose Custom to set the BFF endpoint, tenant code, country/channel IDs, MQTT host and certs by hand for any other region or brand."
         }
       },
       "login_phone": {
         "title": "Sign in with phone (SMS)",
         "description": "Enter the phone number registered on your Omoda/Jaecoo account, its country code (Italy = 39, without +) and the vehicle PIN. A verification code will be sent by SMS; VIN and account ID are detected automatically.{reason}",
         "data": {
+          "preset": "Brand / region preset",
           "phone": "Phone number (without country code)",
           "area_code": "Country code in digits (e.g. 39)",
           "pin": "Vehicle control PIN",
           "bff": "BFF endpoint (region)",
+          "tenant_code": "Tenant code (advanced)",
+          "country_id": "Country ID (advanced)",
           "tsp_host": "TSP console host (region)",
           "car_mqtt_host": "Vehicle MQTT broker host (region)",
           "car_mqtt_port": "Vehicle MQTT broker port (region)",
           "channel_id": "Channel ID (region)",
           "certs_src": "Folder with mutual-TLS certs to import (optional)"
+        },
+        "data_description": {
+          "preset": "Omoda/Jaecoo (Europe) and Chery (Europe) fill in everything automatically. Choose Custom to set the BFF endpoint, tenant code, country/channel IDs, MQTT host and certs by hand for any other region or brand."
         }
       },
       "otp": {

--- a/custom_components/omoda9/translations/en.json
+++ b/custom_components/omoda9/translations/en.json
@@ -13,29 +13,41 @@
         "title": "Sign in with email",
         "description": "Enter your Omoda/Jaecoo account email and vehicle PIN. An OTP code will be sent to your email; VIN and account ID are detected automatically.{reason}",
         "data": {
+          "preset": "Brand / region preset",
           "email": "Account email",
           "pin": "Vehicle control PIN",
           "bff": "BFF endpoint (region)",
+          "tenant_code": "Tenant code (advanced)",
+          "country_id": "Country ID (advanced)",
           "tsp_host": "TSP console host (region)",
           "car_mqtt_host": "Vehicle MQTT broker host (region)",
           "car_mqtt_port": "Vehicle MQTT broker port (region)",
           "channel_id": "Channel ID (region)",
           "certs_src": "Folder with mutual-TLS certs to import (optional)"
+        },
+        "data_description": {
+          "preset": "Omoda/Jaecoo (Europe) and Chery (Europe) fill in everything automatically. Choose Custom to set the BFF endpoint, tenant code, country/channel IDs, MQTT host and certs by hand for any other region or brand."
         }
       },
       "login_phone": {
         "title": "Sign in with phone (SMS)",
         "description": "Enter the phone number registered on your Omoda/Jaecoo account, its country code (Italy = 39, without +) and the vehicle PIN. A verification code will be sent by SMS; VIN and account ID are detected automatically.{reason}",
         "data": {
+          "preset": "Brand / region preset",
           "phone": "Phone number (without country code)",
           "area_code": "Country code in digits (e.g. 39)",
           "pin": "Vehicle control PIN",
           "bff": "BFF endpoint (region)",
+          "tenant_code": "Tenant code (advanced)",
+          "country_id": "Country ID (advanced)",
           "tsp_host": "TSP console host (region)",
           "car_mqtt_host": "Vehicle MQTT broker host (region)",
           "car_mqtt_port": "Vehicle MQTT broker port (region)",
           "channel_id": "Channel ID (region)",
           "certs_src": "Folder with mutual-TLS certs to import (optional)"
+        },
+        "data_description": {
+          "preset": "Omoda/Jaecoo (Europe) and Chery (Europe) fill in everything automatically. Choose Custom to set the BFF endpoint, tenant code, country/channel IDs, MQTT host and certs by hand for any other region or brand."
         }
       },
       "otp": {

--- a/custom_components/omoda9/translations/it.json
+++ b/custom_components/omoda9/translations/it.json
@@ -13,29 +13,41 @@
         "title": "Accedi con email",
         "description": "Inserisci l'email del tuo account Omoda/Jaecoo e il PIN del veicolo. Riceverai un codice OTP via email; VIN e ID account vengono rilevati automaticamente.{reason}",
         "data": {
+          "preset": "Preset marchio / regione",
           "email": "Email dell'account",
           "pin": "PIN di controllo veicolo",
           "bff": "Endpoint BFF (regione)",
+          "tenant_code": "Tenant code (avanzato)",
+          "country_id": "Country ID (avanzato)",
           "tsp_host": "Host console TSP (regione)",
           "car_mqtt_host": "Host broker MQTT del veicolo (regione)",
           "car_mqtt_port": "Porta broker MQTT del veicolo (regione)",
           "channel_id": "Channel ID (regione)",
           "certs_src": "Cartella coi certificati mutual-TLS da importare (opzionale)"
+        },
+        "data_description": {
+          "preset": "Omoda/Jaecoo (Europa) e Chery (Europa) compilano tutto da soli. Scegli «Custom» per impostare a mano BFF, tenant code, country/channel ID, broker MQTT e certificati per qualsiasi altra regione o marchio."
         }
       },
       "login_phone": {
         "title": "Accedi con telefono (SMS)",
         "description": "Inserisci il numero di telefono registrato sul tuo account Omoda/Jaecoo, il prefisso internazionale (Italia = 39, senza +) e il PIN del veicolo. Riceverai un codice via SMS; VIN e ID account vengono rilevati automaticamente.{reason}",
         "data": {
+          "preset": "Preset marchio / regione",
           "phone": "Numero di telefono (senza prefisso)",
           "area_code": "Prefisso internazionale in cifre (es. 39)",
           "pin": "PIN di controllo veicolo",
           "bff": "Endpoint BFF (regione)",
+          "tenant_code": "Tenant code (avanzato)",
+          "country_id": "Country ID (avanzato)",
           "tsp_host": "Host console TSP (regione)",
           "car_mqtt_host": "Host broker MQTT del veicolo (regione)",
           "car_mqtt_port": "Porta broker MQTT del veicolo (regione)",
           "channel_id": "Channel ID (regione)",
           "certs_src": "Cartella coi certificati mutual-TLS da importare (opzionale)"
+        },
+        "data_description": {
+          "preset": "Omoda/Jaecoo (Europa) e Chery (Europa) compilano tutto da soli. Scegli «Custom» per impostare a mano BFF, tenant code, country/channel ID, broker MQTT e certificati per qualsiasi altra regione o marchio."
         }
       },
       "otp": {

--- a/tests/test_capabilities_scheda.py
+++ b/tests/test_capabilities_scheda.py
@@ -321,6 +321,7 @@ def test_il_contesto_non_riceve_capability_inventate(tmp_path):
     c.email, c.phone, c.area_code = "x@y.z", "", "39"
     c.token_path = str(tmp_path / "token.json")
     c.tsp_host, c.bff, c.channel_id = "https://tsp.invalid", "https://bff.invalid", "1"
+    c.tenant_code, c.country_id = "300006", "1"   # i preset aggiungono ctx.tenant_code/country_id
     c.hass = type("H", (), {"config": type("Cf", (), {"path": staticmethod(str)})()})()
     for nome in ("climate_limits", "climate_extremes", "air_durations", "_caps_correnti"):
         setattr(c, nome, (lambda n: lambda: getattr(Omoda9Coordinator, n)(c))(nome))


### PR DESCRIPTION
Adds **brand/region presets** to setup, so a Chery EU account can be onboarded without hand-typing
gateway details.

Chery-International serves Omoda/Jaecoo and Chery from the **same** "legend" backend — the MQTT
broker, TSP console and mutual-TLS certificates are common per region; what differs per brand is the
**BFF gateway, TENANT-CODE, channelId and countryId**. This exposes those and offers one-click
presets:

- **Omoda / Jaecoo — Europe** (default, current behaviour): `legend-oj.omodaauto.nl`, tenant `300006`, channel `1`, country `1`.
- **Chery — Europe**: `eu-chery.cheryinternational.com`, tenant `300001`, channel `2`, country `2`.
- **Custom / other region**: leave every field manual (as today).

### Changes
- `const.py`: `CONF_TENANT_CODE` / `CONF_COUNTRY_ID` (+ `DEFAULTS`) and a `PRESETS` table.
- `config_flow.py`: a brand/region preset dropdown in the login forms; a preset fills BFF + tenant +
  channel + country, "Custom" leaves everything manual. Tenant/country now flow into the login context.
- `coordinator.py`: reads tenant/country from the entry and passes them into the context.
- translations (en / it / strings).

The Chery values were sourced from the official Chery EU app — the same `chery_legend` application
this integration derives from. Existing entries fall back to the historic Omoda values via `DEFAULTS`,
so nothing changes for current setups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
