### PR TITLE
ci: refuse to cut a beta that sorts below the current stable

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -121,6 +121,24 @@ jobs:
             exit 1
           fi
 
+          # La versione del manifest DEVE essere già più avanti dell'ultima stabile.
+          # In semver una pre-release ordina PRIMA della versione omonima: con il
+          # manifest fermo sulla stabile corrente il tag sarebbe `v1.13.0-beta.1`, che
+          # HACS mostra come PIÙ VECCHIO della 1.13.0 installata — non comparirebbe
+          # come aggiornamento, e sceglierlo sarebbe formalmente un downgrade. Una beta
+          # così è peggio di nessuna beta, perché sembra funzionare. Si ferma qui, con
+          # l'istruzione esatta: la versione la decide chi apre la PR, non il workflow —
+          # indovinarla vorrebbe dire pubblicare un numero diverso da quello che poi
+          # uscirà come stabile.
+          stabile=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq '.tag_name' 2>/dev/null | sed 's/^v//' || true)
+          if [ -n "$stabile" ] && [ "$stabile" != "null" ]; then
+            piu_alta=$(printf '%s\n%s\n' "$base" "$stabile" | sort -V | tail -1)
+            if [ "$base" = "$stabile" ] || [ "$piu_alta" = "$stabile" ]; then
+              echo "::error::Il manifest dichiara $base e l'ultima stabile è $stabile, quindi il tag sarebbe v$base-beta.N — che in semver ordina PRIMA di v$stabile e HACS mostrerebbe come più vecchio di quello che l'utente ha già installato. Alza \`version\` in custom_components/omoda9/manifest.json al numero con cui questa modifica uscirà (es. $(echo "$stabile" | awk -F. '{print $1"."$2+1".0"}')), fai commit sul branch della PR e rimetti l'etichetta \`beta\`."
+              exit 1
+            fi
+          fi
+
           # Il contatore è il primo libero fra i TAG (non fra le release: un tag può
           # esistere senza release). Due PR che puntano alla stessa versione non
           # collidono; a distinguerle è il titolo della release, non il tag, così il


### PR DESCRIPTION
A defect in #12, found on its first real use and before it produced anything.

*Attribution, per the convention on #7: the check that surfaced this and the guard below were done by the agent I drive. The decision to stop rather than guess is mine.*

## What would have happened

@Caslinovich and @JackRonan agreed on #14 to put the `beta` label on it so @MassimoDe gets an installable pre-release instead of copying files by hand. That is exactly what the label is for.

But the branch of #14 declares `version: 1.13.0` in the manifest — **the same as the current stable**. The tag would therefore have been `v1.13.0-beta.1`, and in semver a pre-release sorts **before** the version it is named after. HACS would have listed it as *older* than the 1.13.0 the tester already has: never offered as an update, and choosing it is formally a downgrade.

I wrote in #12 that the mechanism "forces whoever opens the pull request to decide the version bump". That is only true if something tells them. Nothing did.

## The fix

Before computing a tag, compare the manifest version against the latest published release and **stop** when it is equal or lower, naming the number to bump to:

```
Il manifest dichiara 1.13.0 e l'ultima stabile è 1.13.0, quindi il tag sarebbe
v1.13.0-beta.N — che in semver ordina PRIMA di v1.13.0 e HACS mostrerebbe come più
vecchio di quello che l'utente ha già installato. Alza `version` in
custom_components/omoda9/manifest.json al numero con cui questa modifica uscirà
(es. 1.14.0), fai commit sul branch della PR e rimetti l'etichetta `beta`.
```

**It does not pick a version.** Guessing would mean publishing a beta under a number different from the stable that eventually follows it, and the version a change ships under is a real decision belonging to its author.

## What was checked, and what was not

**Checked:** the comparison behaves in all five cases — manifest equal to stable and manifest below it both stop; `1.13.1`, `1.14.0` and `2.0.0` against a `1.13.0` stable all proceed. The YAML parses.

**Not checked:** nobody has yet watched this run in Actions, for the same reason as #12 — the honest statement remains that the mechanism has never been observed end to end. Labelling #14 once its manifest is bumped will exercise both this guard and the build in one go.

## Why it is worth its own pull request

This is the same class as publishing a release with no zip attached: a beta that looks fine and cannot work. The difference is that this one fails *silently* — the release appears, the workflow goes green, and the only symptom is a tester saying "it isn't showing up in HACS", days later, on the one path where the tester has been waiting since 18 August.
