### PR TITLE
docs: keep your branch current, and say which part was the agent's

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,32 @@ verified only when a state field on the car changed, at a time you can point to.
 An overstated claim is the only kind of damage in this project that reaches a
 stranger. Wrong code gets found; a wrong claim gets believed.
 
+### Say which part was yours and which was the agent's
+
+Nobody here writes this code by hand; all of us drive a model. So "I read it" and
+"the agent I drive read it" are different claims, and letting them blur is how a
+statement ends up carrying weight it did not earn.
+
+Wherever a claim rests on a **reading, a count or a check**, say who performed it.
+A short line at the top or the bottom is enough:
+
+> *The reading of `routing.py` behind this was done by the agent I drive. The
+> conclusion, and what to do about it, are mine.*
+
+Two rules under that, and the first is absolute:
+
+- **Never write that your human read something they did not read.** Not in a
+  review, not in a pull request, not in a comment. This is the same failure as
+  claiming a car did something it did not do, pointed at ourselves — and it is
+  the one that cannot be walked back, because it is the basis on which everything
+  else here is believed.
+- **State facts so they can be checked without you.** A file and a line beats a
+  summary: `lock.py` line 44 rather than "the lock handling looks correct". Then
+  it does not matter who read it.
+
+This is not about crediting tools. It is that a project which gates on evidence
+has to apply the same standard to how it describes its own work.
+
 ## How a change moves
 
 Land it (small pull request, CI green), it ships to volunteers as a
@@ -121,6 +147,31 @@ git switch -c fix/<short-name> origin/master
 
 Name it for the behaviour, not the file: `fix/charge-energy-undercount`, not
 `fix/coordinator`.
+
+**Keep it current while it is open — not only when it conflicts**
+
+```bash
+git fetch origin
+git merge origin/master
+git push
+```
+
+Do this whenever `master` has moved and your branch has been open more than a day
+or two. Conflicts are the obvious reason and the least important one. The real
+reason is that **a branch that sits behind loses access to whatever arrived after
+it was cut, and finds out by nothing happening**:
+
+- on 24 August the `beta` label was applied to two pull requests in the same
+  minute. One published a pre-release; the other produced **no workflow run at
+  all and no message**. The workflow had landed on `master` a minute after that
+  branch's last commit;
+- a stale branch also carries stale CI. A green tick from five days ago says
+  nothing about today's `master`, and GitHub may not even have recomputed whether
+  the branch still merges.
+
+If you label a pull request and no run appears within a minute, the label did not
+take: push the branch and try again, or use `workflow_dispatch`, which runs from
+the default branch and does not depend on yours.
 
 **Save the work**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,6 +186,12 @@ question as who can review what.
   belong in the private channel, never in this repository.
 - **Claim hardware verification you do not have.** "The backend accepted it" is
   not "the car did it". If you did not watch the car, say so.
+- **Say you read something when your agent read it.** All of us drive a model, so
+  where a claim rests on a reading, a count or a check, say who performed it — one
+  line is enough. This is the same rule as the one above, pointed at ourselves,
+  and the reason for it is the same: everything here is believed on the strength
+  of what we say we checked. Facts stated with a file and a line survive the
+  question entirely.
 - **Remove a function that worked for somebody.** When in doubt the code fails
   open: unknown, unreadable or timed-out means *send exactly as before*. The worst
   an untested path may do is fail to help.


### PR DESCRIPTION
Two rules this week taught us, written down where they will be read rather than left in comment threads.

**Keeping a branch current.** `AGENTS.md` already says "start from an up-to-date `master`" and explains what to do *once a conflict appears*. Both are reactive, and conflicts turn out to be the least important reason.

On 24 August the `beta` label was applied to two pull requests in the same minute. One published a pre-release; the other produced **no workflow run at all and no message**. The workflow had landed on `master` a minute after that branch's last commit. A branch that sits behind loses access to whatever arrived after it was cut, and finds out by *nothing happening* — which is worse than a conflict, because a conflict announces itself. Same shape as reading a five-day-old green tick as if it said something about today's `master`.

So the section now says to merge `master` in while the branch is open, gives the two concrete symptoms, and adds the practical rule: if you label a pull request and no run appears within a minute, the label did not take — push the branch, or use `workflow_dispatch`, which runs from the default branch and does not depend on yours.

**Saying which part was the agent's.** Nobody here writes this code by hand, so "I read it" and "the agent I drive read it" are different claims. This is the hardware-verification rule pointed at ourselves: a project that gates on evidence has to apply the same standard to how it describes its own work. Two clauses under it — never attribute to a person a reading they did not do, and state facts with a file and a line so they can be checked without you.

@Caslinovich and @JackRonan have both been doing this already without being asked, which is why it is worth writing down rather than proposing: it is a description of what the group does, not a new demand.

*Per the rule itself: the two failures cited above are things I ran into today rather than checks run by the agent; the wording is mine.*