### PR TITLE
ci: port pip-audit, CodeQL and Dependabot from the fork line, and NOTICE

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,35 @@
+name: "Omoda / Jaecoo CodeQL config"
+
+# This integration speaks a proprietary OMODA / Chery cloud protocol. The excluded queries below
+# only ever produce false positives here; each exclusion is justified. EVERYTHING ELSE
+# (injection, path traversal, SSRF, deserialization, etc.) stays ON.
+#
+#   py/weak-sensitive-data-hashing
+#     The gateway MANDATES MD5/SHA request signatures, MD5(PIN), and an MD5 MQTT-password
+#     derivation. These are the server's REQUIRED interop wire formats, not local security
+#     controls — there is no stronger primitive the server would accept. (usedforsecurity=False
+#     does not satisfy this CodeQL query, hence the exclusion.)
+#
+#   py/weak-cryptographic-algorithm
+#     The captcha uses AES/ECB/PKCS7 because the AJ-Captcha server issues a per-request key and
+#     expects exactly that mode. Not our choice; cannot change without breaking login.
+#
+#   py/clear-text-logging-sensitive-data
+#     The hits this query produces here are developer CLI / self-test scaffolding inside
+#     `__main__` blocks (e.g. core/provision.py) that do NOT run under Home Assistant and print
+#     masked or mock data. That is the reason for the exclusion, and it is the only one.
+#
+#     Deliberately NOT claimed: that runtime logging can never contain a credential. The
+#     justification carried over from the fork line said exactly that, and `SECURITY.md` no
+#     longer does — sign-in runs in a subprocess whose stdout AND stderr are captured and
+#     logged, so what a failure path carries is a property of the error rather than of our
+#     logging, and this query does not follow that path anyway. Excluding it is about noise,
+#     not about a guarantee. Keep new runtime logging secret-free in review, and treat a
+#     credential reaching a log as a security issue through the private channel.
+query-filters:
+  - exclude:
+      id: py/weak-sensitive-data-hashing
+  - exclude:
+      id: py/weak-cryptographic-algorithm
+  - exclude:
+      id: py/clear-text-logging-sensitive-data

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+# NB: the Python runtime dependencies live in
+# custom_components/omoda9/manifest.json ("requirements"), which Dependabot's
+# pip ecosystem cannot parse. Those are audited by the pip-audit job in
+# .github/workflows/pip-audit.yml. Here we only keep the pinned GitHub Actions fresh.
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,33 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: "23 5 * * 1"   # weekly, Monday 05:23 UTC (static timestamp; no secrets)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (python)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # required to upload CodeQL results
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -1,0 +1,32 @@
+name: pip-audit
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  schedule:
+    - cron: "0 6 * * 1"   # weekly, Monday 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pip-audit:
+    name: pip-audit (manifest runtime deps)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Extract requirements from manifest.json
+        run: |
+          python -c "import json;print('\n'.join(json.load(open('custom_components/omoda9/manifest.json')).get('requirements',[])))" > requirements-manifest.txt
+          cat requirements-manifest.txt
+      - name: Audit
+        # Advisory only: reports known CVEs in the runtime deps (e.g. Pillow) but does
+        # not block — the remedy is a manifest version bump, which is a maintainer's call.
+        run: |
+          pip install pip-audit
+          pip-audit -r requirements-manifest.txt || true

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,8 @@
+DISCLAIMER
+
+This is an UNOFFICIAL project, the result of reverse-engineering. It is NOT
+affiliated with, endorsed by, or supported by Omoda, Jaecoo, Chery, or any of
+their subsidiaries. All trademarks belong to their respective owners. Use at
+your own risk.
+
+The software is licensed under the MIT License (see the LICENSE file).


### PR DESCRIPTION
First code-adjacent instalment of the fork-only port (#10, step 1). Four files added, none modified, and nothing here can reach a car.

**What the canonical line was missing.** No dependency audit, no static analysis, no action updates. All three existed on the fork and none of them came across when the repositories were consolidated:

- **`pip-audit`** — audits the runtime dependencies declared in `manifest.json`, on every pull request and weekly.
- **CodeQL** — Python static analysis, on pull requests and weekly.
- **Dependabot** — updates the GitHub Actions we pin.
- **`NOTICE`** — the unofficial/reverse-engineered disclaimer, which this repository did not carry.

Paths adapted from the fork's domain to this one (`custom_components/omoda_jaecoo` → `custom_components/omoda9`) in two of them.

## Two decisions worth arguing with

**`tests.yml` deliberately not ported.** It duplicates the "Suite di test" job already in `validate.yml` — the same pytest run, differing only by a 3.12/3.13 matrix and by the requirements filename. A second red/green signal for the same thing costs attention and buys nothing. If somebody wants the 3.12 leg specifically — and there is an argument for it, since `core/` is supposed to be exercisable without Home Assistant — that belongs as a matrix entry on the existing job, not as a second workflow.

**One justification rewritten rather than copied, and this one matters.** The CodeQL config excludes `py/clear-text-logging-sensitive-data`. The fork's comment justified that with:

> Runtime logging was audited (see the v1.5.45 security pass) and **never logs PIN/OTP/tokens**.

`SECURITY.md`, merged this morning, deliberately declines to make that claim: sign-in runs in a subprocess whose **stdout and stderr are both captured and logged**, so what a failure path carries is a property of the error rather than of our logging. Porting the comment as written would have imported an absolute we retracted four hours earlier — into the configuration of the query that nominally covers it.

The exclusion stays, because the hits really are `__main__` scaffolding that never runs under Home Assistant. But it is now justified by the noise rather than by a guarantee, and the comment says which of the two it is. @Caslinovich — this is the same class of thing as your own errata: the code was fine, the document said more than the code could support.

## What was checked

**Checked:** all four files parse as YAML; the two domain-specific paths are the only fork references, and both are adapted; nothing modifies existing files.

**Not checked:** none of these three workflows has ever run on this repository, so the first run is the test. CodeQL in particular may report findings on a codebase it has not seen before — that is the point of adding it, and any findings are a separate conversation rather than an argument against merging the configuration.

**Still to port** from the fork line, and none of it is mechanical the way this was: `select.py`, `sandbox/`, `core/otp_result.py`, the phone tests, and the home/away charging-energy work with its `At Home` sensor (now #29). All of it is Python written against v1.8.0 and has to be checked against a `core/` that has since become a package taking an explicit context — @Caslinovich found this afternoon that the June charging probe no longer runs for exactly that reason. The Lovelace card and `card.yml` are @JackRonan's in #21 and are not mine to bring across.

*Per the convention now in `CONTRIBUTING.md`: the comparison between the two lines' workflows, and the check that `tests.yml` duplicates the existing job, were done by the agent I drive. The decision not to port it, and to rewrite the CodeQL justification rather than copy it, are mine.*
