### PR TITLE
sensor: work out the range unit from the car's own data, not from a constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ dell'integrazione: aggiorna da **HACS → Omoda 9 / Jaecoo → Aggiorna**.
 
 ## [Non rilasciato]
 
+## v1.14.0 — 2026-08-24
+
 ### 🇮🇹 Italiano
 
 - **«Autonomia benzina (miglia)» ora capisce da sola in che unità parla l'auto.** È un

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ dell'integrazione: aggiorna da **HACS → Omoda 9 / Jaecoo → Aggiorna**.
 
 ## [Non rilasciato]
 
+### 🇮🇹 Italiano
+
+- **«Autonomia benzina (miglia)» ora capisce da sola in che unità parla l'auto.** È un
+  sensore di diagnostica, e finora dava per scontato che quel dato arrivasse in miglia —
+  cosa vera sulla Omoda 9, ma dedotta da due sole letture di una sola macchina. Su un
+  modello che lo mandasse in chilometri, Home Assistant avrebbe convertito un numero già
+  metrico e mostrato **un'autonomia più lunga di una volta e mezza**. Adesso il confronto
+  con l'autonomia benzina normale, che arriva sempre in chilometri, dice quale delle due
+  cose sta succedendo. Sulla Omoda 9 non cambia niente: il numero è identico a prima.
+- **Un dato incompleto non fa più comparire un numero sbagliato.** Se in una lettura manca
+  il valore di confronto, quel sensore tiene l'ultimo numero buono invece di mostrarne uno
+  che potrebbe essere falso — e che sarebbe rimasto lì fino alla lettura dopo.
+
+### 🇬🇧 English
+
+- **"Petrol range (miles)" now works out for itself which unit the car is speaking.** It is
+  a diagnostic sensor, and until now it assumed that reading arrived in miles — true on the
+  Omoda 9, but worked out from two readings of a single car. On a model sending kilometres
+  instead, Home Assistant would have converted an already-metric number and shown **a range
+  half again as long as the real one**. It now compares against the ordinary petrol range,
+  which always arrives in kilometres, and that comparison settles which case it is. On an
+  Omoda 9 nothing changes: the number is identical to before.
+- **An incomplete reading no longer produces a wrong number.** When the value needed for
+  that comparison is missing, the sensor keeps the last good number instead of showing one
+  that might be false — and that would have stayed on screen until the next reading.
+
 ## v1.13.0 — 2026-08-10
 
 ### 🇮🇹 Italiano

--- a/custom_components/omoda9/manifest.json
+++ b/custom_components/omoda9/manifest.json
@@ -14,5 +14,5 @@
     "numpy>=1.21",
     "pillow>=9.0"
   ],
-  "version": "1.13.0"
+  "version": "1.14.0"
 }

--- a/custom_components/omoda9/sensor.py
+++ b/custom_components/omoda9/sensor.py
@@ -157,6 +157,82 @@ def _frame_batteria_degradato(rt: dict) -> bool:
     return v == 0.0
 
 
+def _cruise_range_miglia(rt: dict):
+    """`cruiseRange` espresso in MIGLIA — o niente, se l'auto non permette di deciderlo.
+
+    ── Il fatto misurato ────────────────────────────────────────────────────────────────
+    Il centralino manda ALCUNE grandezze due volte, in due unità, come campi fratelli.
+    Frame reale di un'Omoda 9 PHEV, 2026-08-24:
+
+        mileageSurplus     209 km   ↔  cruiseRange            130   (rapporto 1,6077)
+        pureElectricRange  145 km   ↔  pureElectricRangeMile   90   (rapporto 1,6111)
+        lFrontTyreKpa      283      ↔  lFrontTyrePsi           41   (rapporto 6,90)
+
+    Sono TRE grandezze, non tutte: `odometer`, `averageFuel` e le temperature arrivano una
+    volta sola. E il dizionario dei campi dell'app contiene un gemello di `mileageSurplus`
+    con un nome dedicato (`mileageSurplusMile`) che quest'auto **non manda**: quindi
+    l'identificazione di `cruiseRange` come gemello imperiale è un'inferenza da tre campioni
+    su una sola auto, non l'accoppiamento dichiarato dal costruttore.
+
+    ── Perché non basta più inchiodare le miglia ────────────────────────────────────────
+    Il sensore dichiarava miglia per costante. Se su un altro modello quel campo fosse in
+    chilometri, Home Assistant convertirebbe un valore già metrico e mostrerebbe 1,6 volte
+    l'autonomia vera. ⚠️ **Non è dimostrato che accada**: la misura di @ThomasMeyer1970 sul
+    Jaecoo J7 riguarda `mileageSurplus`, non questo campo, e la lettura che chiuderebbe la
+    questione è stata chiesta (issue #3, e il filo su #7) e non è ancora tornata. Questa
+    funzione è quindi una difesa, non la correzione di un difetto osservato.
+
+    ── Come decide, e le tre cose da cui si difende ─────────────────────────────────────
+    Sul rapporto fra due campi, che è una misura, e non sui selettori `rangeUnit` (dei quali
+    si sa solo che esistono e che nella famiglia `*Unit` si osservano sia 1 sia 2 — su campi
+    DIVERSI: `rangeUnit` è sempre stato 1 in ogni campione conservato, il 2 è di
+    `avgHkPowerUnit`. Che 1 e 2 significhino km e miglia **non è misurato**).
+
+    1. **Senza ancora non si indovina, e non si ripiega sul grezzo.** Manca o è zero
+       `mileageSurplus` ⇒ `None` ⇒ resta l'ultimo valore noto. Restituire il grezzo
+       sembrerebbe «fail open» ma su un'auto in chilometri farebbe **riapparire il difetto
+       per quel frame** (misurato: 209 → 336,35 km) e per giunta lo scriverebbe nell'ultimo
+       noto. È lo stesso guasto già pagato in v1.7.1 con `_range_totale`.
+    2. **L'ancora si verifica quando l'auto lo consente.** Se arriva la coppia gemella *per
+       nome* `pureElectricRange`/`pureElectricRangeMile`, il suo rapporto dice se i campi
+       senza suffisso di QUEL veicolo sono metrici. Se lo nega, non si decide.
+
+    ⚠️ **Limite noto, non coperto e non copribile da qui.** Non è detto che `cruiseRange` sia
+    l'autonomia benzina: sul fork l'entità si chiama «Range Combined (Estimate)». Se su un
+    modello fosse l'autonomia ELETTRICA in chilometri, il rapporto con `mileageSurplus`
+    potrebbe valere ~1,609 per pura aritmetica (su una PHEV con 209 km di benzina e 130 di
+    elettrico è esattamente così) e la funzione direbbe «è già in miglia». Una guardia che
+    confronti `cruiseRange` con `pureElectricRange` è stata scritta e poi **rimossa**: in quel
+    caso restituiva lo stesso identico valore del ramo normale — un ramo che non cambia niente
+    è codice morto travestito da sicurezza — e in cambio faceva congelare il sensore sulla
+    nostra auto ogni volta che l'autonomia elettrica, scendendo, passava vicino al valore di
+    `cruiseRange`. Il caso si chiude con una misura sul J7, non con una difesa a indovinare.
+
+    Un solo cancello converte: rapporto ≈1 fra `cruiseRange` e `mileageSurplus`. In ogni
+    altro caso si spedisce il grezzo, cioè le miglia di sempre.
+    """
+    mi = _primo(rt, "cruiseRange")
+    if mi is None or mi <= 0:
+        # 0 è un segnaposto che il sensore pubblicava già come 0: non lo si trasforma.
+        return mi
+
+    # (2) l'ancora è verificabile? La coppia gemella PER NOME è l'unica prova diretta che i
+    # campi senza suffisso di questo veicolo siano metrici.
+    e_km = _primo(rt, *ELEC_RANGE_FIELDS)
+    e_mi = _primo(rt, "pureElectricRangeMile")
+    if e_km and e_mi and not (1.50 <= e_km / e_mi <= 1.72):
+        return mi
+
+    # (1) l'ancora
+    km = _primo(rt, "mileageSurplus")
+    if km is None or km <= 0:
+        return None
+
+    if 0.93 <= km / mi <= 1.07:        # stesso numero ⇒ cruiseRange è in chilometri
+        return mi / 1.609344
+    return mi                           # tutto il resto: il grezzo, come si è sempre fatto
+
+
 def _range_totale(rt: dict):
     """Autonomia totale REALE = elettrica (`pureElectricRange`) + benzina (`mileageSurplus`).
     None se manca un pezzo → resta l'ultimo valore noto (RestoreSensor).
@@ -219,8 +295,13 @@ _RT_SENSORS: list[_RtSpec] = [
     # mostrerà ~182 km invece di un "113 km" che sarebbe semplicemente falso.
     # precision=0: la conversione miglia→km produce 181,855872, sei decimali di
     # falsa precisione su un dato che l'auto manda arrotondato all'unità.
+    # L'unità DICHIARATA resta miglia — stabile, così Home Assistant non registra un
+    # cambio di unità e non spezza lo storico — mentre è il VALORE a essere normalizzato
+    # per veicolo. Vedi _cruise_range_miglia: l'unità è una proprietà dell'auto, non una
+    # costante del codice.
     _RtSpec("range_combinato", "Autonomia benzina (miglia)", "cruiseRange",
-            DIST, MIGLIA, MEAS, "mdi:map-marker-distance", diag=True, precision=0),
+            DIST, MIGLIA, MEAS, "mdi:map-marker-distance", diag=True, precision=0,
+            compute=_cruise_range_miglia),
     _RtSpec("odometro", "Odometro", "odometer",
             DIST, KM, TOTAL, "mdi:counter"),
     _RtSpec("km_ibrido", "Chilometraggio ibrido", "hybridMileage",

--- a/tests/test_unita_autonomia.py
+++ b/tests/test_unita_autonomia.py
@@ -1,0 +1,111 @@
+"""L'unità dell'autonomia è una proprietà del VEICOLO, non una costante del codice.
+
+Il centralino manda alcune grandezze in due unità come campi fratelli: `mileageSurplus` in
+chilometri e `cruiseRange` in miglia (misurato dal vivo su Omoda 9: 209 km ↔ 130). Il
+sensore diagnostico dichiarava miglia **per costante**, da due campioni su una sola auto.
+
+⚠️ Non è dimostrato che su un altro modello quel campo sia in chilometri: la misura sul
+Jaecoo J7 riguarda `mileageSurplus` (issue #3, e il filo su #7), non questo campo. Questi
+test fissano quindi una DIFESA, non la correzione di un difetto osservato — e soprattutto
+fissano le tre cose da cui la difesa deve difendersi, perché ognuna, sbagliata, farebbe
+danno a chi oggi funziona.
+"""
+from __future__ import annotations
+
+import pytest
+
+from custom_components.omoda9.sensor import _cruise_range_miglia
+
+MIGLIO_KM = 1.609344
+# Frame vero, 2026-08-24. Serve come base a cui togliere un pezzo per volta.
+OMODA9 = {"mileageSurplus": "209", "cruiseRange": "130",
+          "pureElectricRange": "145", "pureElectricRangeMile": "90"}
+
+
+# ── il caso che NON deve cambiare ────────────────────────────────────────────────────
+def test_omoda9_reale_passa_intatto():
+    assert _cruise_range_miglia(OMODA9) == 130.0
+
+
+@pytest.mark.parametrize("km,mi", [("182", "113"), ("215", "134")])
+def test_i_due_campioni_storici_passano_intatti(km, mi):
+    """I campioni di giugno e luglio su cui era stata dedotta l'unità: nessuno si muove."""
+    assert _cruise_range_miglia({"mileageSurplus": km, "cruiseRange": mi}) == float(mi)
+
+
+# ── il caso per cui la difesa esiste ─────────────────────────────────────────────────
+def test_auto_che_manda_i_km_viene_convertita():
+    v = _cruise_range_miglia({"mileageSurplus": "209", "cruiseRange": "209"})
+    assert v == pytest.approx(209 / MIGLIO_KM, abs=0.01)
+    assert v * MIGLIO_KM == pytest.approx(209, abs=0.01)   # HA riconverte: torna 209 km
+
+
+# ── LA SOGLIA: l'unico cancello che converte davvero ─────────────────────────────────
+# Senza questi quattro, spostare 0,93 a 0,10 o 1,07 a 1,49 non farebbe fallire niente:
+# provato con mutazione, quattro mutanti su quattro sopravvivevano.
+@pytest.mark.parametrize("rapporto,converte", [
+    (0.92, False), (0.93, True), (1.07, True), (1.08, False),
+])
+def test_i_bordi_della_finestra_di_conversione(rapporto, converte):
+    mi = 130.0
+    rt = {"cruiseRange": str(mi), "mileageSurplus": str(mi * rapporto)}
+    v = _cruise_range_miglia(rt)
+    if converte:
+        assert v == pytest.approx(mi / MIGLIO_KM, abs=0.01), "dentro la finestra: deve convertire"
+    else:
+        assert v == mi, "fuori dalla finestra: si tiene il grezzo, non si inventa"
+
+
+# ── (1) senza ancora si TIENE L'ULTIMO NOTO, non si ripiega sul grezzo ───────────────
+def test_senza_ancora_non_si_pubblica_un_numero_possibilmente_falso():
+    """Il grezzo qui sarebbe il difetto di ritorno: su un'auto in km 209 diventerebbe
+    336,35 km sul quadro di HA, e finirebbe pure nell'ultimo valore noto. `None` lascia in
+    piedi l'ultimo numero già giusto. Stesso guasto corretto in v1.7.1 su `_range_totale`."""
+    assert _cruise_range_miglia({"cruiseRange": "130"}) is None
+    assert _cruise_range_miglia({"cruiseRange": "130", "mileageSurplus": "0"}) is None
+
+
+def test_un_frame_parziale_non_sporca_la_serie():
+    """Sequenza reale: frame pieno, frame senza ancora, frame pieno. In mezzo nessun salto."""
+    pieno = _cruise_range_miglia(OMODA9)
+    parziale = _cruise_range_miglia({k: v for k, v in OMODA9.items() if k != "mileageSurplus"})
+    assert pieno == 130.0
+    assert parziale is None          # ⇒ RestoreSensor tiene 130, nessuna spuntata a 336 km
+    assert _cruise_range_miglia(OMODA9) == 130.0
+
+
+# ── (2) e (3) le due guardie ─────────────────────────────────────────────────────────
+def test_limite_noto_se_fosse_lautonomia_elettrica_non_ce_ne_accorgeremmo():
+    """Documenta un LIMITE, non una difesa — e va letto come tale.
+
+    Se su un modello `cruiseRange` fosse l'autonomia elettrica in chilometri, il rapporto con
+    `mileageSurplus` può valere ~1,609 per pura aritmetica e la funzione direbbe «è già in
+    miglia». Una guardia dedicata è stata scritta e rimossa perché restituiva lo stesso
+    valore del ramo normale (ramo morto) e faceva congelare il sensore sulla nostra auto.
+    Questo test fissa il comportamento attuale così che, se un giorno lo si cambia, lo si
+    faccia sapendo di cambiarlo."""
+    rt = {"mileageSurplus": "209", "cruiseRange": "130", "pureElectricRange": "130"}
+    assert _cruise_range_miglia(rt) == 130.0
+
+
+def test_se_la_coppia_gemella_nega_i_km_non_si_decide():
+    """`pureElectricRange`/`pureElectricRangeMile` sono gemelli per NOME: se il loro
+    rapporto non è ~1,609, i campi senza suffisso di quest'auto non sono metrici e l'ancora
+    non vale."""
+    rt = dict(OMODA9, mileageSurplus="130", pureElectricRange="145", pureElectricRangeMile="145")
+    assert _cruise_range_miglia(rt) == 130.0
+
+
+# ── valori degeneri: uno per riga, niente parametrize a maglie larghe ────────────────
+def test_zero_resta_zero():
+    """⚠️ 0 è un segnaposto che il sensore pubblicava già come 0. Trasformarlo in `None`
+    farebbe ricomparire l'ultimo valore noto al posto di uno zero vero."""
+    assert _cruise_range_miglia({"cruiseRange": "0", "mileageSurplus": "209"}) == 0.0
+
+
+def test_campo_assente_e_none():
+    assert _cruise_range_miglia({}) is None
+
+
+def test_campo_non_numerico_e_none():
+    assert _cruise_range_miglia({"cruiseRange": "abc", "mileageSurplus": "209"}) is None


### PR DESCRIPTION
## What changes, and why

- sensor: work out the range unit from the car's own data, not from a constant

## Evidence

Non dichiarata: pull request aperta senza terminale.

## Checks

- [x] Suite green (`pytest tests/ -q`) — cancello R12 di `pr.sh`
- [x] Entity count unchanged — `tests/test_entity_count.py`, dentro la suite
- [x] No VIN, token, certificate, account id or raw capture — cancello R02 (`check_secrets.sh`)
- [ ] Fails open: nothing here can take away a function that worked for somebody
- [ ] Design docs updated if this contradicts them
