### PR TITLE
feat(sensor): home/away charging energy and the At Home sensor, ported from the fork line

### DIFF
--- a/custom_components/omoda9/binary_sensor.py
+++ b/custom_components/omoda9/binary_sensor.py
@@ -152,8 +152,12 @@ class Omoda9ACasa(Omoda9Entity, BinarySensorEntity):
     finche' non c'e' un fix utilizzabile.
 
     Comodo per automazioni e schede che vogliono il booleano senza interpretare lo stato del
-    device_tracker. Condivide `car_zone` con i contatori di energia casa/fuori: se i due
-    divergessero, l'utente vedrebbe l'auto a casa e l'energia contata come fuori."""
+    device_tracker: risponde con la zona piu' PICCOLA che contiene l'auto, quindi in un
+    garage disegnato dentro casa dice `off`. E' la convenzione di Home Assistant e resta.
+
+    I contatori di energia NON usano questa funzione ma `in_zona_casa`, che chiede il
+    contenimento in `zone.home`: le due domande sono diverse e tenerle diverse e' voluto —
+    la presenza dice dove sei, l'energia dice a chi va addebitata."""
 
     _attr_device_class = BinarySensorDeviceClass.PRESENCE
     _attr_icon = "mdi:home-map-marker"

--- a/custom_components/omoda9/binary_sensor.py
+++ b/custom_components/omoda9/binary_sensor.py
@@ -159,7 +159,7 @@ class Omoda9ACasa(Omoda9Entity, BinarySensorEntity):
     _attr_icon = "mdi:home-map-marker"
 
     def __init__(self, coord) -> None:
-        super().__init__(coord, "A casa", "at_home", entity_id_format=ENTITY_ID_FORMAT)
+        super().__init__(coord, "Omoda9 A casa", "at_home", entity_id_format=ENTITY_ID_FORMAT)
 
     @property
     def available(self) -> bool:

--- a/custom_components/omoda9/binary_sensor.py
+++ b/custom_components/omoda9/binary_sensor.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import DOMAIN, FIELDS_AS_RICH_ENTITY
 from .coordinator import SENSORS
-from .entity import Omoda9Entity, field_on
+from .entity import Omoda9Entity, car_zone, field_on
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, add: AddEntitiesCallback) -> None:
@@ -34,6 +34,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, add: AddEnt
     ents.append(Omoda9Online(coord))
     ents.append(Omoda9Awake(coord))
     ents.append(Omoda9Session(coord))
+    ents.append(Omoda9ACasa(coord))
     # — avvisi dal canale realtime (Round B): gomme + batteria scarica —
     for suffix, name, field, dc in _RT_BINARIES:
         ents.append(Omoda9RealtimeBinary(coord, name, suffix, field, dc))
@@ -143,6 +144,33 @@ class Omoda9RealtimeBinary(_Omoda9RestoreBinary):
     def _live_is_on(self) -> bool | None:
         rt = self.coordinator.data.get("realtime") or {}
         return field_on(rt[self._field]) if self._field in rt else None
+
+
+class Omoda9ACasa(Omoda9Entity, BinarySensorEntity):
+    """Se l'auto si trova dentro la zona `home` di Home Assistant, dalla sua posizione GPS
+    viva — stessa logica di zona del device_tracker. ON = a casa, OFF = fuori, `unknown`
+    finche' non c'e' un fix utilizzabile.
+
+    Comodo per automazioni e schede che vogliono il booleano senza interpretare lo stato del
+    device_tracker. Condivide `car_zone` con i contatori di energia casa/fuori: se i due
+    divergessero, l'utente vedrebbe l'auto a casa e l'energia contata come fuori."""
+
+    _attr_device_class = BinarySensorDeviceClass.PRESENCE
+    _attr_icon = "mdi:home-map-marker"
+
+    def __init__(self, coord) -> None:
+        super().__init__(coord, "A casa", "at_home", entity_id_format=ENTITY_ID_FORMAT)
+
+    @property
+    def available(self) -> bool:
+        # Deriva dalla posizione: con l'aggiornamento automatico spento il fix GPS non viene
+        # rinfrescato e questo riporterebbe un casa/fuori potenzialmente vecchio.
+        return bool(self.coordinator.poll_enabled)
+
+    @property
+    def is_on(self) -> bool | None:
+        zona = car_zone(self.hass, self.coordinator.data.get("position"))
+        return None if zona is None else zona == "home"
 
 
 class Omoda9Awake(Omoda9Entity, BinarySensorEntity):

--- a/custom_components/omoda9/const.py
+++ b/custom_components/omoda9/const.py
@@ -251,6 +251,17 @@ HV_ON_POLL_MAX = 90     # cap di sicurezza al numero di letture ravvicinate (~90
 # in ricarica una lettura realtime dà subito stato_ricarica/corrente_hv/tempo_residuo aggiornati.
 CHARGING_POLL_EVERY = 120   # secondi tra due letture realtime mentre la spina è collegata (carica)
 CHARGING_POLL_MAX = 300     # cap di sicurezza (~10h: copre una carica AC completa con margine)
+# Intervallo massimo (secondi) fra due campioni di ricarica ancora integrati nei contatori
+# di energia casa/fuori. Durante una carica il poll realtime gira ogni CHARGING_POLL_EVERY
+# (120 s); un buco piu' largo significa che l'auto si e' addormentata o ha smesso di
+# riportare, quindi NON si integra attraverso di esso — altrimenti si inventerebbe energia.
+# 300 s = si tollera un poll perso, si rifiutano i buchi di sonno.
+#
+# ATTENZIONE, difetto noto e portato di proposito senza correggerlo: su cariche AC lente con
+# polling rado quasi tutta la sessione cade nei buchi e il contatore SOTTOSTIMA. Caso reale
+# misurato sulla linea fork: 0,53 kWh contati contro ~8,2 kWh ricavati dal SoC. Correggerlo
+# e' un cambiamento a se', per non confondere il porting con il fix.
+CHARGE_ENERGY_MAX_GAP = 300
 # MARCIA (battito di rilevamento): l'auto IN MOVIMENTO non manda push MQTT (verificato dal vivo
 # 2026-06-24: a vettura in marcia la sessione MQTT è connessa ma non arriva alcun 5A02 → motore/
 # velocità restavano fermi al giorno prima) e il poll periodico "sveglia+leggi" è ogni ~ora. Senza

--- a/custom_components/omoda9/entity.py
+++ b/custom_components/omoda9/entity.py
@@ -29,14 +29,22 @@ def _flt(v):
 
 
 def car_zone(hass, position: dict | None) -> str | None:
-    """`"home"` / `"away"` / `None` (ignoto) per una posizione GPS viva, usando la logica di
-    zona di Home Assistant (`async_active_zone`) — LA STESSA che mette il device_tracker
-    dell'auto su `home`/`not_home`. `None` quando non c'e' un fix utilizzabile, cosi' chi
-    chiama puo' astenersi invece di tirare a indovinare.
+    """`"home"` / `"away"` / `None` (ignoto), con la semantica del DEVICE_TRACKER.
 
-    Sorgente unica condivisa dal binary sensor "A casa" e dai contatori di energia di
-    ricarica casa/fuori: se i due divergessero, l'utente vedrebbe l'auto a casa e l'energia
-    contata come fuori, e non avrebbe modo di sapere quale dei due ha ragione.
+    Usa `async_active_zone`, cioe' la stessa funzione che mette il device_tracker dell'auto
+    su `home`/`not_home`. `None` quando non c'e' un fix utilizzabile, cosi' chi chiama puo'
+    astenersi invece di tirare a indovinare.
+
+    ⚠️ **`async_active_zone` restituisce la zona piu' PICCOLA che contiene il punto**, non
+    `zone.home`. Una zona non passiva disegnata dentro casa — un garage, un vialetto, cioe'
+    esattamente il posto dove sta una wallbox — vince su `zone.home`, e questa funzione
+    risponde `"away"` per un'auto che e' a casa. Misurato da @Caslinovich: con una
+    `zone.garage` da 20 m sulle stesse coordinate, una ricarica domestica finiva nel
+    contatore "fuori".
+
+    Per una entita' di PRESENZA quel comportamento e' la convenzione di Home Assistant e
+    resta. Per un CONTATORE DI ENERGIA e' sbagliato: la domanda li' non e' "in che zona
+    sei" ma "sei dentro casa", e la risposta e' `in_zona_casa()`.
     """
     # import locale: nessuna dipendenza dal componente zone al momento dell'import del modulo
     from homeassistant.components.zone import async_active_zone
@@ -50,6 +58,34 @@ def car_zone(hass, position: dict | None) -> str | None:
     if zone is None:
         return "away"
     return "home" if zone.entity_id == "zone.home" else "away"
+
+
+def in_zona_casa(hass, position: dict | None) -> bool | None:
+    """L'auto e' DENTRO `zone.home`? `None` se non c'e' un fix utilizzabile.
+
+    Domanda diversa da `car_zone()`, e va tenuta diversa. Quella chiede *in che zona sei* e
+    risponde con la piu' piccola che ti contiene — corretto per una presenza, sbagliato per
+    l'energia: chi carica nel proprio garage sta caricando a casa, qualunque zona piu'
+    stretta ci sia disegnata sopra.
+
+    Qui si chiede il CONTENIMENTO in `zone.home` e basta. Nessuna zona piu' piccola puo'
+    cambiare la risposta, e nessuna zona che l'utente aggiunge domani puo' spostare in
+    silenzio l'energia da un contatore all'altro.
+
+    `None` se `zone.home` non esiste: senza il riferimento non si indovina, e i contatori si
+    astengono invece di attribuire.
+    """
+    from homeassistant.components.zone import in_zone
+
+    pos = position or {}
+    lat = _flt(pos.get("lat") or pos.get("latitude"))
+    lon = _flt(pos.get("lon") or pos.get("longitude"))
+    if lat is None or lon is None:
+        return None
+    casa = hass.states.get("zone.home")
+    if casa is None:
+        return None
+    return bool(in_zone(casa, lat, lon))
 
 
 def field_on(v) -> bool | None:

--- a/custom_components/omoda9/entity.py
+++ b/custom_components/omoda9/entity.py
@@ -20,6 +20,38 @@ from .const import DEFAULT_VEHICLE_NAME, DOMAIN, OPT_MAX_S
 from .coordinator import Omoda9Coordinator
 
 
+def _flt(v):
+    """float() oppure None (non solleva mai)."""
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def car_zone(hass, position: dict | None) -> str | None:
+    """`"home"` / `"away"` / `None` (ignoto) per una posizione GPS viva, usando la logica di
+    zona di Home Assistant (`async_active_zone`) — LA STESSA che mette il device_tracker
+    dell'auto su `home`/`not_home`. `None` quando non c'e' un fix utilizzabile, cosi' chi
+    chiama puo' astenersi invece di tirare a indovinare.
+
+    Sorgente unica condivisa dal binary sensor "A casa" e dai contatori di energia di
+    ricarica casa/fuori: se i due divergessero, l'utente vedrebbe l'auto a casa e l'energia
+    contata come fuori, e non avrebbe modo di sapere quale dei due ha ragione.
+    """
+    # import locale: nessuna dipendenza dal componente zone al momento dell'import del modulo
+    from homeassistant.components.zone import async_active_zone
+
+    pos = position or {}
+    lat = _flt(pos.get("lat") or pos.get("latitude"))
+    lon = _flt(pos.get("lon") or pos.get("longitude"))
+    if lat is None or lon is None:
+        return None
+    zone = async_active_zone(hass, lat, lon)
+    if zone is None:
+        return "away"
+    return "home" if zone.entity_id == "zone.home" else "away"
+
+
 def field_on(v) -> bool | None:
     """Interpreta un campo 5A02 come acceso/aperto (True), spento/chiuso (False)
     o ASSENTE (None).

--- a/custom_components/omoda9/sensor.py
+++ b/custom_components/omoda9/sensor.py
@@ -540,7 +540,10 @@ class Omoda9ChargedEnergy(Omoda9Entity, RestoreSensor):
 
     def __init__(self, coord, *, home: bool) -> None:
         self._home = home
-        nome = "Energia ricarica a casa" if home else "Energia ricarica fuori casa"
+        # Il prefisso "Omoda9" e' la convenzione di questo file: da li' esce l'object_id
+        # `omoda9_...` dell'entity_id, e la translation_key e' quella senza prefisso.
+        nome = ("Omoda9 Energia ricarica a casa" if home
+                else "Omoda9 Energia ricarica fuori casa")
         super().__init__(coord, nome,
                          "energy_charged_home" if home else "energy_charged_away",
                          entity_id_format=ENTITY_ID_FORMAT)

--- a/custom_components/omoda9/sensor.py
+++ b/custom_components/omoda9/sensor.py
@@ -24,6 +24,7 @@ from homeassistant.const import (
     EntityCategory,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
+    UnitOfEnergy,
     UnitOfLength,
     UnitOfPower,
     UnitOfPressure,
@@ -35,9 +36,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN, FIELDS_AS_RICH_ENTITY
+from .const import CHARGE_ENERGY_MAX_GAP, DOMAIN, FIELDS_AS_RICH_ENTITY
 from .coordinator import SENSORS
-from .entity import Omoda9Entity
+from .entity import Omoda9Entity, car_zone
 
 
 # ───────────────────────── sensori "realtime" (Round B) ─────────────────────────
@@ -343,6 +344,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, add: AddEnt
     # Piano di partenza programmata: dato che l'auto ci manda già a ogni sonda e che finora
     # buttavamo via. Sola lettura — il comando `appointmentTravel` non è implementato.
     ents.append(Omoda9DeparturePlan(coord))
+    # Contatori energia di ricarica casa/fuori (solo BEV: `chargingPower` esiste solo li').
+    # Due entita' e non una con attributo: nella dashboard Energia una sorgente e' un'entita'.
+    ents.append(Omoda9ChargedEnergy(coord, home=True))
+    ents.append(Omoda9ChargedEnergy(coord, home=False))
     # — sensori "ricchi" dal canale realtime (Round B): autonomia, odometro, gomme,
     #   consumi, ricarica, clima target —
     # Su BEV CONFERMATA (powerType == 0) si tolgono i sensori del motore termico e si
@@ -489,6 +494,110 @@ class Omoda9Speed(_Omoda9RestoreSensor):
             return float(rt["vehicleSpeed"]) if "vehicleSpeed" in rt else None
         except (TypeError, ValueError):
             return None
+
+
+def _in_ricarica(v) -> bool:
+    """True se `chargeState` dice "in ricarica".
+
+    Tollera la forma float `'1.0'` che il canale realtime manda a volte: un confronto
+    ingenuo `str(v) == "1"` teneva l'integrale fermo a zero senza dirlo — difetto trovato
+    sulla linea fork e non ripetuto qui."""
+    try:
+        return float(v) == 1.0
+    except (TypeError, ValueError):
+        return False
+
+
+class Omoda9ChargedEnergy(Omoda9Entity, RestoreSensor):
+    """Energia caricata mentre l'auto sta DENTRO (`home=True`) o FUORI (`home=False`) dalla
+    zona `home` di Home Assistant.
+
+    E' una STIMA: l'integrale trapezoidale di `chargingPower` (kW, solo BEV) nel tempo,
+    accumulato solo mentre l'auto sta effettivamente caricando E la sua posizione GPS viva
+    cade dentro o fuori dalla zona di casa — la stessa logica di zona che HA usa per il
+    device_tracker, condivisa via `car_zone`.
+
+    Contatore di vita (`TOTAL_INCREASING`, kWh): si mette direttamente nella dashboard
+    Energia come sorgente. Casa + Fuori ≈ energia totale caricata, divisa per luogo.
+
+    Note sull'accuratezza, da leggere prima di fidarsi del numero:
+      - i campioni arrivano dal poll realtime (~120 s durante la carica) → qualche punto
+        percentuale di scarto da un contatore vero. Va bene per la dashboard Energia, NON
+        e' una lettura fiscale;
+      - gli intervalli piu' larghi di `CHARGE_ENERGY_MAX_GAP` NON vengono integrati, cosi'
+        un buco di sonno non puo' inventare energia. **Il rovescio e' un difetto noto: su
+        cariche AC lente con polling rado quasi tutta la sessione cade nei buchi e il
+        contatore sottostima** (misurato: 0,53 kWh contati contro ~8,2 ricavati dal SoC).
+        Portato cosi' di proposito, si corregge a parte;
+      - quando la posizione viva e' ignota NESSUNO dei due contatori accumula: l'energia non
+        viene mai attribuita alla zona sbagliata.
+    """
+
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_suggested_display_precision = 2
+
+    def __init__(self, coord, *, home: bool) -> None:
+        self._home = home
+        nome = "Energia ricarica a casa" if home else "Energia ricarica fuori casa"
+        super().__init__(coord, nome,
+                         "energy_charged_home" if home else "energy_charged_away",
+                         entity_id_format=ENTITY_ID_FORMAT)
+        self._attr_icon = "mdi:home-lightning-bolt" if home else "mdi:ev-station"
+        self._energia_wh: float = 0.0
+        self._ultimo_ts = None
+        self._ultima_potenza: float = 0.0
+        self._era_attivo: bool = False
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        last = await self.async_get_last_sensor_data()
+        if last is not None and last.native_value is not None:
+            try:
+                val = float(last.native_value)
+            except (TypeError, ValueError):
+                val = None
+            if val is not None and val >= 0:
+                self._energia_wh = val * 1000.0
+
+    def _campiona(self) -> None:
+        """Un passo di integrazione trapezoidale, a ogni aggiornamento del coordinator."""
+        try:
+            potenza = float(_rt(self.coordinator, "chargingPower") or 0.0)
+        except (TypeError, ValueError):
+            potenza = 0.0
+        carica = _in_ricarica(_rt(self.coordinator, "chargeState")) and potenza > 0
+        zona = car_zone(self.hass, self.coordinator.data.get("position"))
+        atteso = "home" if self._home else "away"
+        attivo = carica and zona is not None and zona == atteso
+
+        ora = dt_util.utcnow()
+        # si integra SOLO su un intervallo i cui DUE estremi erano attivi e vicini nel tempo
+        if attivo and self._era_attivo and self._ultimo_ts is not None:
+            dt_s = (ora - self._ultimo_ts).total_seconds()
+            if 0 < dt_s <= CHARGE_ENERGY_MAX_GAP:
+                # kW·h → Wh:  media(kW) * (s/3600) * 1000
+                self._energia_wh += 0.5 * (self._ultima_potenza + potenza) * (dt_s / 3600.0) * 1000.0
+        self._ultimo_ts = ora
+        self._ultima_potenza = potenza if attivo else 0.0
+        self._era_attivo = attivo
+
+    def _handle_coordinator_update(self) -> None:
+        self._campiona()
+        super()._handle_coordinator_update()
+
+    @property
+    def available(self) -> bool:
+        # Sono contatori che integrano nel TEMPO: accumulano sul trapezio fra due campioni
+        # realtime consecutivi. Con l'aggiornamento automatico spento l'auto viene letta una
+        # volta sola (il seed all'avvio), due campioni attivi consecutivi non arrivano mai e
+        # il valore non puo' crescere → meglio UNAVAILABLE che uno zero fermo e ingannevole.
+        return bool(self.coordinator.poll_enabled)
+
+    @property
+    def native_value(self) -> float:
+        return round(self._energia_wh / 1000.0, 3)
 
 
 class Omoda9RealtimeSensor(_Omoda9RestoreSensor):

--- a/custom_components/omoda9/sensor.py
+++ b/custom_components/omoda9/sensor.py
@@ -38,7 +38,7 @@ from homeassistant.util import dt as dt_util
 
 from .const import CHARGE_ENERGY_MAX_GAP, DOMAIN, FIELDS_AS_RICH_ENTITY
 from .coordinator import SENSORS
-from .entity import Omoda9Entity, car_zone
+from .entity import Omoda9Entity, in_zona_casa
 
 
 # ───────────────────────── sensori "realtime" (Round B) ─────────────────────────
@@ -515,7 +515,8 @@ class Omoda9ChargedEnergy(Omoda9Entity, RestoreSensor):
     E' una STIMA: l'integrale trapezoidale di `chargingPower` (kW, solo BEV) nel tempo,
     accumulato solo mentre l'auto sta effettivamente caricando E la sua posizione GPS viva
     cade dentro o fuori dalla zona di casa — la stessa logica di zona che HA usa per il
-    device_tracker, condivisa via `car_zone`.
+    device_tracker — ma chiedendo il CONTENIMENTO in `zone.home` (`in_zona_casa`) e non
+    la zona attiva, perche' un garage disegnato dentro casa non deve spostare l'energia.
 
     Contatore di vita (`TOTAL_INCREASING`, kWh): si mette direttamente nella dashboard
     Energia come sorgente. Casa + Fuori ≈ energia totale caricata, divisa per luogo.
@@ -571,9 +572,11 @@ class Omoda9ChargedEnergy(Omoda9Entity, RestoreSensor):
         except (TypeError, ValueError):
             potenza = 0.0
         carica = _in_ricarica(_rt(self.coordinator, "chargeState")) and potenza > 0
-        zona = car_zone(self.hass, self.coordinator.data.get("position"))
-        atteso = "home" if self._home else "away"
-        attivo = carica and zona is not None and zona == atteso
+        # CONTENIMENTO in `zone.home`, non "in che zona sei": chi carica nel proprio garage
+        # sta caricando a casa, e una zona piu' stretta disegnata sopra non deve spostare
+        # l'energia da un contatore all'altro. Vedi `in_zona_casa` per il perche'.
+        a_casa = in_zona_casa(self.hass, self.coordinator.data.get("position"))
+        attivo = carica and a_casa is not None and a_casa == self._home
 
         ora = dt_util.utcnow()
         # si integra SOLO su un intervallo i cui DUE estremi erano attivi e vicini nel tempo

--- a/custom_components/omoda9/strings.json
+++ b/custom_components/omoda9/strings.json
@@ -155,6 +155,9 @@
   },
   "entity": {
     "binary_sensor": {
+      "a_casa": {
+        "name": "A casa"
+      },
       "alta_tensione_attiva": {
         "name": "High voltage active"
       },
@@ -345,6 +348,12 @@
       },
       "dati_auto_aggiornati": {
         "name": "Car data updated"
+      },
+      "energia_ricarica_a_casa": {
+        "name": "Energia ricarica a casa"
+      },
+      "energia_ricarica_fuori_casa": {
+        "name": "Energia ricarica fuori casa"
       },
       "esito_comando": {
         "name": "Command result"

--- a/custom_components/omoda9/translations/en.json
+++ b/custom_components/omoda9/translations/en.json
@@ -155,6 +155,9 @@
   },
   "entity": {
     "binary_sensor": {
+      "a_casa": {
+        "name": "At home"
+      },
       "alta_tensione_attiva": {
         "name": "High voltage active"
       },
@@ -345,6 +348,12 @@
       },
       "dati_auto_aggiornati": {
         "name": "Car data updated"
+      },
+      "energia_ricarica_a_casa": {
+        "name": "Home charging energy"
+      },
+      "energia_ricarica_fuori_casa": {
+        "name": "Away charging energy"
       },
       "esito_comando": {
         "name": "Command result"

--- a/custom_components/omoda9/translations/it.json
+++ b/custom_components/omoda9/translations/it.json
@@ -155,6 +155,9 @@
   },
   "entity": {
     "binary_sensor": {
+      "a_casa": {
+        "name": "A casa"
+      },
       "alta_tensione_attiva": {
         "name": "Alta tensione attiva"
       },
@@ -345,6 +348,12 @@
       },
       "dati_auto_aggiornati": {
         "name": "Dati auto aggiornati"
+      },
+      "energia_ricarica_a_casa": {
+        "name": "Energia ricarica a casa"
+      },
+      "energia_ricarica_fuori_casa": {
+        "name": "Energia ricarica fuori casa"
       },
       "esito_comando": {
         "name": "Esito comando"

--- a/tests/test_energia_ricarica.py
+++ b/tests/test_energia_ricarica.py
@@ -39,8 +39,8 @@ def _contatore(home=True):
     return e
 
 
-def _campiona(e, coord, zona, istante, monkeypatch):
-    monkeypatch.setattr(S, "car_zone", lambda hass, pos: zona)
+def _campiona(e, coord, a_casa, istante, monkeypatch):
+    monkeypatch.setattr(S, "in_zona_casa", lambda hass, pos: a_casa)
     monkeypatch.setattr(S.dt_util, "utcnow", lambda: istante)
     e.coordinator = coord
     e.hass = None
@@ -64,9 +64,9 @@ def test_stato_carica_float_conta_come_in_ricarica():
 def test_trapezio_su_due_campioni_vicini(monkeypatch):
     """2 kW per 120 s = 0,0667 kWh. Il primo campione arma soltanto: non accumula."""
     e = _contatore(home=True)
-    _campiona(e, _CoordFinto("2.0"), "home", T0, monkeypatch)
+    _campiona(e, _CoordFinto("2.0"), True, T0, monkeypatch)
     assert e.native_value == 0.0
-    _campiona(e, _CoordFinto("2.0"), "home", T0 + dt.timedelta(seconds=120), monkeypatch)
+    _campiona(e, _CoordFinto("2.0"), True, T0 + dt.timedelta(seconds=120), monkeypatch)
     assert e.native_value == pytest.approx(2.0 * 120 / 3600, abs=1e-3)
 
 
@@ -78,14 +78,14 @@ def test_buco_lungo_non_inventa_energia(monkeypatch):
     deliberato finche' non viene corretto a parte: il test lo fissa perche' nessuno lo
     cambi per sbaglio credendolo un bug di battitura."""
     e = _contatore(home=True)
-    _campiona(e, _CoordFinto("2.0"), "home", T0, monkeypatch)
+    _campiona(e, _CoordFinto("2.0"), True, T0, monkeypatch)
     troppo_tardi = T0 + dt.timedelta(seconds=CHARGE_ENERGY_MAX_GAP + 1)
-    _campiona(e, _CoordFinto("2.0"), "home", troppo_tardi, monkeypatch)
+    _campiona(e, _CoordFinto("2.0"), True, troppo_tardi, monkeypatch)
     assert e.native_value == 0.0
 
 
 def test_zona_ignota_non_attribuisce_a_nessuno(monkeypatch):
-    """Senza fix GPS l'energia non finisce nel contatore sbagliato: non finisce da nessuna
+    """Senza fix GPS o senza `zone.home` l'energia non finisce nel contatore sbagliato: non finisce da nessuna
     parte. Meglio perdere un campione che attribuirlo alla zona sbagliata."""
     for casa in (True, False):
         e = _contatore(home=casa)
@@ -98,8 +98,8 @@ def test_i_due_contatori_si_dividono_la_carica(monkeypatch):
     """La stessa carica a casa accumula su `home` e lascia `away` a zero."""
     casa, fuori = _contatore(home=True), _contatore(home=False)
     for e in (casa, fuori):
-        _campiona(e, _CoordFinto("2.0"), "home", T0, monkeypatch)
-        _campiona(e, _CoordFinto("2.0"), "home", T0 + dt.timedelta(seconds=120), monkeypatch)
+        _campiona(e, _CoordFinto("2.0"), True, T0, monkeypatch)
+        _campiona(e, _CoordFinto("2.0"), True, T0 + dt.timedelta(seconds=120), monkeypatch)
     assert casa.native_value > 0
     assert fuori.native_value == 0.0
 
@@ -107,6 +107,6 @@ def test_i_due_contatori_si_dividono_la_carica(monkeypatch):
 def test_potenza_zero_non_accumula(monkeypatch):
     """`chargeState` puo' dire "in ricarica" mentre la potenza e' ancora 0: non e' energia."""
     e = _contatore(home=True)
-    _campiona(e, _CoordFinto("0"), "home", T0, monkeypatch)
-    _campiona(e, _CoordFinto("0"), "home", T0 + dt.timedelta(seconds=120), monkeypatch)
+    _campiona(e, _CoordFinto("0"), True, T0, monkeypatch)
+    _campiona(e, _CoordFinto("0"), True, T0 + dt.timedelta(seconds=120), monkeypatch)
     assert e.native_value == 0.0

--- a/tests/test_energia_ricarica.py
+++ b/tests/test_energia_ricarica.py
@@ -1,0 +1,112 @@
+"""Contatori di energia di ricarica casa/fuori: l'aritmetica dell'integrale.
+
+Questi test guardano il PASSO DI CAMPIONAMENTO, non il cablaggio a Home Assistant:
+l'entita' viene costruita senza passare dal costruttore, perche' cio' che puo' essere
+sbagliato qui e' il trapezio, il rifiuto dei buchi e l'attribuzione alla zona — non
+l'istanziazione, che la suite delle entita' copre gia' altrove.
+
+Tre di questi fallivano sulla forma ingenua del codice, quindi sono test di regressione e
+non decorazione:
+  * `test_buco_lungo_non_inventa_energia`
+  * `test_zona_ignota_non_attribuisce_a_nessuno`
+  * `test_stato_carica_float_conta_come_in_ricarica`
+"""
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+from custom_components.omoda9 import sensor as S
+from custom_components.omoda9.const import CHARGE_ENERGY_MAX_GAP
+
+
+class _CoordFinto:
+    def __init__(self, potenza, stato="1", posizione=None):
+        self.data = {"realtime": {"chargingPower": potenza, "chargeState": stato},
+                     "position": posizione or {"lat": 1.0, "lon": 2.0}}
+        self.poll_enabled = True
+
+
+def _contatore(home=True):
+    """Istanza senza costruttore: qui interessa solo lo stato dell'integratore."""
+    e = object.__new__(S.Omoda9ChargedEnergy)
+    e._home = home
+    e._energia_wh = 0.0
+    e._ultimo_ts = None
+    e._ultima_potenza = 0.0
+    e._era_attivo = False
+    return e
+
+
+def _campiona(e, coord, zona, istante, monkeypatch):
+    monkeypatch.setattr(S, "car_zone", lambda hass, pos: zona)
+    monkeypatch.setattr(S.dt_util, "utcnow", lambda: istante)
+    e.coordinator = coord
+    e.hass = None
+    e._campiona()
+
+
+T0 = dt.datetime(2026, 8, 24, 12, 0, 0, tzinfo=dt.timezone.utc)
+
+
+def test_stato_carica_float_conta_come_in_ricarica():
+    """Il canale realtime manda a volte `'1.0'`: un confronto con la stringa `'1'` teneva
+    l'integrale fermo a zero senza dirlo."""
+    assert S._in_ricarica("1") is True
+    assert S._in_ricarica("1.0") is True
+    assert S._in_ricarica(1.0) is True
+    assert S._in_ricarica("0") is False
+    assert S._in_ricarica(None) is False
+    assert S._in_ricarica("chi lo sa") is False
+
+
+def test_trapezio_su_due_campioni_vicini(monkeypatch):
+    """2 kW per 120 s = 0,0667 kWh. Il primo campione arma soltanto: non accumula."""
+    e = _contatore(home=True)
+    _campiona(e, _CoordFinto("2.0"), "home", T0, monkeypatch)
+    assert e.native_value == 0.0
+    _campiona(e, _CoordFinto("2.0"), "home", T0 + dt.timedelta(seconds=120), monkeypatch)
+    assert e.native_value == pytest.approx(2.0 * 120 / 3600, abs=1e-3)
+
+
+def test_buco_lungo_non_inventa_energia(monkeypatch):
+    """Oltre CHARGE_ENERGY_MAX_GAP l'auto ha dormito: non si integra attraverso il buco.
+
+    E' anche il difetto noto dei contatori — su cariche AC lente con polling rado
+    l'energia vera cade qui dentro e il contatore sottostima. Il comportamento e'
+    deliberato finche' non viene corretto a parte: il test lo fissa perche' nessuno lo
+    cambi per sbaglio credendolo un bug di battitura."""
+    e = _contatore(home=True)
+    _campiona(e, _CoordFinto("2.0"), "home", T0, monkeypatch)
+    troppo_tardi = T0 + dt.timedelta(seconds=CHARGE_ENERGY_MAX_GAP + 1)
+    _campiona(e, _CoordFinto("2.0"), "home", troppo_tardi, monkeypatch)
+    assert e.native_value == 0.0
+
+
+def test_zona_ignota_non_attribuisce_a_nessuno(monkeypatch):
+    """Senza fix GPS l'energia non finisce nel contatore sbagliato: non finisce da nessuna
+    parte. Meglio perdere un campione che attribuirlo alla zona sbagliata."""
+    for casa in (True, False):
+        e = _contatore(home=casa)
+        _campiona(e, _CoordFinto("2.0"), None, T0, monkeypatch)
+        _campiona(e, _CoordFinto("2.0"), None, T0 + dt.timedelta(seconds=120), monkeypatch)
+        assert e.native_value == 0.0
+
+
+def test_i_due_contatori_si_dividono_la_carica(monkeypatch):
+    """La stessa carica a casa accumula su `home` e lascia `away` a zero."""
+    casa, fuori = _contatore(home=True), _contatore(home=False)
+    for e in (casa, fuori):
+        _campiona(e, _CoordFinto("2.0"), "home", T0, monkeypatch)
+        _campiona(e, _CoordFinto("2.0"), "home", T0 + dt.timedelta(seconds=120), monkeypatch)
+    assert casa.native_value > 0
+    assert fuori.native_value == 0.0
+
+
+def test_potenza_zero_non_accumula(monkeypatch):
+    """`chargeState` puo' dire "in ricarica" mentre la potenza e' ancora 0: non e' energia."""
+    e = _contatore(home=True)
+    _campiona(e, _CoordFinto("0"), "home", T0, monkeypatch)
+    _campiona(e, _CoordFinto("0"), "home", T0 + dt.timedelta(seconds=120), monkeypatch)
+    assert e.native_value == 0.0

--- a/tests/test_entity_count.py
+++ b/tests/test_entity_count.py
@@ -34,8 +34,8 @@ from custom_components.omoda9.const import (
 # che l'auto ci manda già a ogni sonda (`appointmentTravelSetVOS`) e che finora buttavamo via.
 # Nessuna chiamata nuova verso il cloud: solo un campo che smettevamo di ignorare.
 ATTESO = {
-    "binary_sensor": 26,
-    "sensor": 39,
+    "binary_sensor": 27,
+    "sensor": 41,
     "button": 14,
     "switch": 18,
     "cover": 3,
@@ -46,7 +46,11 @@ ATTESO = {
     "text": 1,
     "time": 1,
 }
-TOTALE_ATTESO = 107
+# 107 -> 110 il 2026-08-24: portati dalla linea fork i due contatori di energia di ricarica
+# (casa/fuori) e il binary sensor "A casa". Cambiamento DELIBERATO e annunciato: questo numero
+# e' il criterio di accettazione che @Caslinovich ha adottato per le fette architetturali, e
+# non deve muoversi per caso.
+TOTALE_ATTESO = 110
 
 
 def test_totale_dichiarato_coerente():

--- a/tests/test_entity_count.py
+++ b/tests/test_entity_count.py
@@ -50,6 +50,23 @@ ATTESO = {
 # (casa/fuori) e il binary sensor "A casa". Cambiamento DELIBERATO e annunciato: questo numero
 # e' il criterio di accettazione che @Caslinovich ha adottato per le fette architetturali, e
 # non deve muoversi per caso.
+#
+# DUE COSE CHE QUESTO NUMERO NON DICE PIU', e che chi lo legge dopo non indovinerebbe.
+#
+# 1. "N entita', zero unavailable" ha smesso di essere un segnale pulito. Quelle tre sono le
+#    PRIME entita' del progetto che possono essere `unavailable` PER DISEGNO: tutte e tre
+#    dipendono da `coordinator.poll_enabled`, SPENTO su un'installazione nuova, e su
+#    contatori che integrano nel tempo uno zero fermo sarebbe piu' ingannevole. Finora
+#    `unavailable` significava "entita' orfana rimasta da un cambio di tipo" ed era il modo
+#    per accorgersene: da qui in avanti, tre unavailable sono normali.
+#
+# 2. Due delle tre sono contate su un profilo che nessuno ha ancora dimostrato di poter
+#    esercitare. I contatori leggono `chargingPower`, classificato BEV-only in
+#    `_RT_SENSORI_BEV` sulla base di una cattura del 2026-06-25 presa ad auto SCOLLEGATA,
+#    dove quel campo non poteva esserci comunque. Non esiste alcuna cattura di un'Omoda 9
+#    fatta durante una carica. Se `chargingPower` arrivasse anche su una PHEV quella lista ha
+#    una voce di troppo; se non arrivasse, i due contatori vanno nel ramo BEV. Serve UN frame
+#    di sola lettura da un'auto attaccata alla spina.
 TOTALE_ATTESO = 110
 
 

--- a/tests/test_zone_casa.py
+++ b/tests/test_zone_casa.py
@@ -1,0 +1,80 @@
+"""Le due domande sulla zona, provate direttamente e non aggirate.
+
+Rilievo di @Caslinovich nella lettura di #33: `car_zone` era l'unica superficie condivisa
+nuova **senza un test diretto** — tutti i test dei contatori la sostituivano con un
+monkeypatch, quindi il confronto con `zone.home`, il ripiego su lat/lon e il ramo
+"nessuna zona" non erano coperti. Ed era la funzione di cui aveva chiesto la lettura.
+
+Qui si prova la differenza che conta, e che era il difetto: `async_active_zone` restituisce
+la zona **piu' piccola** che contiene il punto, quindi un garage disegnato dentro casa
+vince su `zone.home`. Per una presenza e' giusto cosi'; per l'energia no.
+"""
+from __future__ import annotations
+
+import pytest
+
+from custom_components.omoda9.entity import car_zone, in_zona_casa
+
+CASA = {"lat": 45.0, "lon": 9.0}
+
+
+@pytest.fixture
+async def zone_casa(hass):
+    """Solo `zone.home`, sulle coordinate di CASA."""
+    hass.config.latitude, hass.config.longitude = CASA["lat"], CASA["lon"]
+    await hass.async_block_till_done()
+    return hass
+
+
+@pytest.fixture
+async def zone_casa_e_garage(zone_casa):
+    """`zone.home` con dentro un `zone.garage` da 20 m sullo stesso punto."""
+    from homeassistant.setup import async_setup_component
+
+    await async_setup_component(zone_casa, "zone", {"zone": [{
+        "name": "Garage", "latitude": CASA["lat"], "longitude": CASA["lon"], "radius": 20,
+    }]})
+    await zone_casa.async_block_till_done()
+    return zone_casa
+
+
+# ───────────────────────── senza fix GPS ─────────────────────────
+
+@pytest.mark.parametrize("pos", [None, {}, {"lat": None, "lon": 9.0}, {"lat": "boh", "lon": "x"}])
+async def test_senza_posizione_usabile_entrambe_si_astengono(zone_casa, pos):
+    """`None` e non un valore inventato: chi chiama deve poter distinguere "non lo so"
+    da "fuori", altrimenti l'energia finisce nel contatore sbagliato a ogni buco GPS."""
+    assert car_zone(zone_casa, pos) is None
+    assert in_zona_casa(zone_casa, pos) is None
+
+
+# ───────────────────────── con la sola zone.home ─────────────────────────
+
+async def test_dentro_casa_le_due_concordano(zone_casa):
+    assert car_zone(zone_casa, CASA) == "home"
+    assert in_zona_casa(zone_casa, CASA) is True
+
+
+async def test_lontano_da_casa_le_due_concordano(zone_casa):
+    lontano = {"lat": 46.5, "lon": 11.5}
+    assert car_zone(zone_casa, lontano) == "away"
+    assert in_zona_casa(zone_casa, lontano) is False
+
+
+async def test_accetta_anche_latitude_longitude(zone_casa):
+    """Il canale realtime nomina i campi in due modi; entrambi devono funzionare."""
+    assert in_zona_casa(zone_casa, {"latitude": CASA["lat"], "longitude": CASA["lon"]}) is True
+
+
+# ───────────────────────── il difetto: una zona dentro casa ─────────────────────────
+
+async def test_un_garage_dentro_casa_separa_le_due_risposte(zone_casa_e_garage):
+    """IL test di questo file, ed e' il difetto che la lettura di #33 ha trovato.
+
+    `async_active_zone` restituisce la zona piu' piccola, quindi per il device_tracker
+    l'auto e' "nel garage" e non "a casa" — corretto per una presenza. Se i contatori di
+    energia usassero la stessa risposta, una ricarica domestica finirebbe nel contatore
+    "fuori" per il solo fatto che l'utente ha disegnato una zona sopra la propria wallbox.
+    """
+    assert car_zone(zone_casa_e_garage, CASA) == "away"       # semantica device_tracker
+    assert in_zona_casa(zone_casa_e_garage, CASA) is True     # contenimento: e' a casa

--- a/tests/test_zone_casa.py
+++ b/tests/test_zone_casa.py
@@ -20,22 +20,33 @@ CASA = {"lat": 45.0, "lon": 9.0}
 
 @pytest.fixture
 async def zone_casa(hass):
-    """Solo `zone.home`, sulle coordinate di CASA."""
+    """Solo `zone.home`, sulle coordinate di CASA.
+
+    NB: impostare `hass.config.latitude/longitude` NON crea l'entita' `zone.home` — la
+    crea l'avvio del componente `zone`, a partire da quelle coordinate. Impararlo e' costato
+    una CI rossa."""
+    from homeassistant.setup import async_setup_component
+
     hass.config.latitude, hass.config.longitude = CASA["lat"], CASA["lon"]
+    assert await async_setup_component(hass, "zone", {})
     await hass.async_block_till_done()
+    assert hass.states.get("zone.home") is not None
     return hass
 
 
 @pytest.fixture
-async def zone_casa_e_garage(zone_casa):
+async def zone_casa_e_garage(hass):
     """`zone.home` con dentro un `zone.garage` da 20 m sullo stesso punto."""
     from homeassistant.setup import async_setup_component
 
-    await async_setup_component(zone_casa, "zone", {"zone": [{
+    hass.config.latitude, hass.config.longitude = CASA["lat"], CASA["lon"]
+    assert await async_setup_component(hass, "zone", {"zone": [{
         "name": "Garage", "latitude": CASA["lat"], "longitude": CASA["lon"], "radius": 20,
     }]})
-    await zone_casa.async_block_till_done()
-    return zone_casa
+    await hass.async_block_till_done()
+    assert hass.states.get("zone.home") is not None
+    assert hass.states.get("zone.garage") is not None
+    return hass
 
 
 # ───────────────────────── senza fix GPS ─────────────────────────


### PR DESCRIPTION
Closes #29.

Three entities this line never had: two lifetime kWh counters splitting charging energy by whether the car sat **inside** or **outside** the Home Assistant `home` zone, and the binary sensor that says which. They drop straight into the Energy dashboard as sources — home cost against public columns.

## Ported, not rewritten

Every hook the fork used has an equivalent here, which is why this is additive rather than a rewrite: `get_rt_field` → `_rt()`, the charge-state convention, `chargingPower`, `data["position"]`, `coordinator.poll_enabled`, and `Omoda9Entity.__init__` takes the same arguments as its counterpart. The two `sensor.py` files turn out to be structurally parallel — same class hierarchy, same names modulo the prefix — with `ChargedEnergy` the one class the fork had and this line did not.

**Names and entity ids follow this line's convention** (Italian, like every other sensor in the file) rather than the fork's. The domain rename will change the ids for everybody anyway, and consistency inside the file is what a reader needs.

**`car_zone()` goes in `entity.py` as one shared source of truth** for the binary sensor and both counters. If those ever diverged a user would see the car at home and the energy counted as away, with no way to tell which was right.

**Taken from the fork and not from the merged repository, deliberately.** That merge lost the `At Home` sensor while keeping the energy card that references it three times — noted when the delta checklist was extracted, and this is where it would have bitten.

## This ships a known defect on purpose

`CHARGE_ENERGY_MAX_GAP` refuses to integrate across intervals wider than 300 s, so a sleep gap cannot invent energy. The other side of that is real and measured: **on slow AC charges with sparse polling almost the whole session falls into those gaps and the counter underreports** — 0.53 kWh counted against ~8.2 kWh reconstructed from SoC, on the fork line.

It is ported unchanged, and the reason is that a port has to stay verifiable against its source. Mixing the fix in here would mean nobody could tell whether a difference from the fork was the port or the correction — and on a counter that feeds the Energy dashboard, that is exactly the distinction worth keeping. The behaviour is pinned by a test so nobody removes the guard thinking it is a typo, and the constant carries the measurement in a comment. The fix is a separate change with its own evidence.

## The number that moves, and who needs to know

**Entity count 107 → 110.** @Caslinovich — this is the figure you adopted as your acceptance criterion for the architecture slices ("615 tests green, 107 entities, zero `unavailable`"). It moves here, deliberately, and `tests/test_entity_count.py` is updated in the same commit with the reason written next to it. After this it is **110**. Flagging it rather than letting you find it against a slice.

## What was checked, and what was not

**Checked:** every symbol the ported class needs exists in this line, verified one by one; all files parse; the three translation keys are present in `strings.json`, `it.json` and `en.json` with matching counts (41 sensors, 27 binary sensors).

**Not checked: the suite has not been run.** Home Assistant needs Python 3.13+ and this machine is on 3.11 — the same reason `validate.yml` carries a comment saying CI is the only place the suite is a real gate. So CI is the gate here, and if it is red the fault is mine rather than the port's.

**Not verified on a car at all.** Both counters are BEV-only (`chargingPower` exists only there) and depend on a `home` zone being configured. Nobody has watched this accumulate on this line. It ran for weeks on the fork, which is evidence about the code and not about this integration — the ordinary condition here.

Six tests, and three of them fail on the naive form of this code rather than decorating it: the long-gap rejection, the unknown-zone abstention, and `chargeState` arriving as `'1.0'` instead of `'1'` — which on the fork silently kept the integral at zero for a while.

## Two items leave the port list

`tests/test_normalize_phone.py` and `tests/test_reconfigure_phone.py` are already here under Italian names (`test_normalizza_telefono.py`, `test_reconfigure_telefono.py`). Still outstanding from the fork-only delta: `select.py`, `sandbox/`, `core/otp_result.py` — the last of which waits, because it rewires error handling inside `config_flow.py` where @JackRonan has four pull requests open.

*Per the convention in `CONTRIBUTING.md`: the symbol-by-symbol comparison between the two lines, and the transcription of the class, were done by the agent I drive. The decision to port the defect unchanged rather than fix it in passing is mine, and so is the naming.*
