### PR TITLE
tools: the rules of this repository, in a form that can be run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,10 +13,20 @@ omoda9_diag.off
 # --- runtime / dati locali ---
 data/
 venv/
+.venv/
+.venv-test/
 __pycache__/
 *.pyc
 *.bak
 *.bak_*
+
+# --- tooling: local registers and personal patterns, never tracked ---
+# tools/private-patterns.txt holds the very strings check-secrets.sh exists to catch
+# (a surname inside an e-mail, home paths, machine names): committing it publishes them.
+DEROGATIONS.log
+DEROGHE.log
+COMMENTI.log
+tools/private-patterns.txt
 
 # IDE
 .vscode/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,3 +203,15 @@ If you are working with a coding agent — and most of us are — point it at
 above plus the literal git and GitHub commands for branching, opening a pull
 request, syncing and getting out of trouble. You are not expected to know
 GitHub to contribute here.
+
+Everything above is prose, and prose is a thing to remember rather than a thing that
+stops you. [`tools/`](tools/) is the same rules written so a machine can check them:
+numbered `R01`–`R26`, each one pointing back at the paragraph here or in `AGENTS.md`
+that it comes from, and each one saying whether it blocks, warns, or merely asks.
+`./tools/rules.sh list` prints the table. Where a rule has **no** paragraph behind it in this
+repository, it is marked a house rule of whoever wrote the scripts, rather than
+presented as something the group agreed.
+
+Using it is optional and always will be: `git push` and `gh pr create` are in
+`AGENTS.md` for a reason. The point of putting it here is that a rule only one machine
+can enforce is a rule the rest of us are guessing at.

--- a/custom_components/omoda9/core/commands.py
+++ b/custom_components/omoda9/core/commands.py
@@ -14,8 +14,8 @@ Header: Authorization=<userToken>, timestamp=<ms>, Content-Type=application/json
 
 ⚠️  Ogni send() col taskId valido ATTUA sull'auto. È pensato per essere invocato SOLO
     dal tap di Rino su un pulsante in Home Assistant (= suo consenso esplicito).
-    Catalogo body ricostruito 1:1 dagli envelope reali in
-    /root/omoda9_capture_20260620/command_envelopes.txt.
+    Catalogo body ricostruito 1:1 dagli envelope reali catturati dall'app ufficiale
+    (materiale di cattura: canale privato, mai in questo repo).
 """
 import os
 import json

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -180,7 +180,7 @@ REALTIME_ASLEEP = {"code": "A07900"}
 # Sono omesse le 98 voci FIGLIE del ramo 1 (stato veicolo, `parentId` 101): verificate tutte a 1,
 # e nessun comando le tocca. Restano le altre 182 — i comandi dei rami 2/3/4 più le cinque radici,
 # fra cui il 101 stesso — che sono quelle che decidono.
-# Fonte grezza: /root/omoda9-project/45_capability/permessi_jaecoo7_phev_eu.json
+# Fonte grezza: la lista permessi letta su un Jaecoo 7 PHEV EU (canale privato, mai in questo repo).
 JAECOO7_PHEV_EU = {
     1: 1, 2: 1, 3: 1, 4: 1, 101: 1, 201: 0, 202: 1, 203: 1,
     204: 1, 205: 1, 206: 1, 207: 1, 208: 1, 209: 1, 210: 0, 211: 1,

--- a/tests/test_repo_hygiene.py
+++ b/tests/test_repo_hygiene.py
@@ -4,9 +4,13 @@ Il repo è **pubblico**. Nella stessa cartella di lavoro convivono due mondi:
 
   * il **package pubblicabile** (`custom_components/omoda9/`, README, LICENSE, hacs.json,
     CHANGELOG) — ciò che finisce su GitHub e da lì in HACS;
-  * il **tooling interno** (script di release, handoff, il ponte legacy, questa suite) e
-    i **dati per-account** (certificati, token, `.env`, file del monitor diagnostico) —
-    che devono restare su disco ma fuori dal set tracciato.
+  * il **materiale privato** (dati per-account: certificati, token, `.env`, file del
+    monitor diagnostico; il ponte legacy; gli handoff personali) — che deve restare su
+    disco ma fuori dal set tracciato.
+
+Il *tooling* non sta più in questo secondo gruppo: da quando vive in `tools/` è parte del
+repo e si legge e si esegue in quattro. Restano vietati i suoi **vecchi nomi alla radice**,
+che sono le copie rimaste sul disco di chi lo usava quando era privato.
 
 `check_secrets.sh` è il gate bloccante prima di ogni release e scandaglia tutta la
 history. Questi test sono la rete a maglie più larghe che gira però a OGNI esecuzione
@@ -32,16 +36,26 @@ def _git(*args: str) -> str:
 @pytest.fixture(scope="module")
 def tracciati() -> list[str]:
     """I file che git considera parte del repo (quindi pubblici)."""
-    if not os.path.isdir(os.path.join(REPO, ".git")):
+    # ⚠️ `isdir` da solo salta in silenzio dentro un git worktree, dove `.git` è un FILE
+    # che punta alla directory comune. Questi test sono passati in locale e falliti in CI
+    # proprio per questo: si controlla l'esistenza, non il tipo.
+    if not os.path.exists(os.path.join(REPO, ".git")):
         pytest.skip("non è una checkout git")
     return [r for r in _git("ls-files").splitlines() if r.strip()]
 
 
-# nomi/estensioni che NON devono mai comparire fra i file tracciati
+# nomi che NON devono mai comparire fra i file tracciati, a qualsiasi profondità
 VIETATI_ESATTI = {
-    "omoda9.env", "token.json", ".mqtt_cred", ".gh_token",
-    "check_secrets.sh", "deploy.sh", "release.sh", "ha_bridge.py",
-    "hacs_refresh.py",
+    "omoda9.env", "token.json", ".mqtt_cred", ".gh_token", "ha_bridge.py",
+    "hacs_refresh.py", "private-patterns.txt",
+    "DEROGATIONS.log", "DEROGHE.log", "COMMENTI.log",
+}
+# nomi vietati SOLO alla radice: sono le vecchie copie private del tooling, che oggi vive
+# in `tools/` ed è tracciato apposta. Vietarli ovunque bocciava `tools/release.sh` — cioè
+# la pull request che pubblica il tooling — ed è come questo test ha scoperto la modifica.
+VIETATI_ALLA_RADICE = {
+    "check_secrets.sh", "deploy.sh", "release.sh", "pr.sh", "regole.sh",
+    "commento.sh", "REGOLE.md",
 }
 VIETATI_SUFFISSI = (
     ".key", ".pem", ".cer", ".p12", ".pfx",      # materiale crittografico
@@ -56,6 +70,7 @@ def test_nessun_segreto_fra_i_file_tracciati(tracciati):
     colpevoli = [
         r for r in tracciati
         if os.path.basename(r) in VIETATI_ESATTI
+        or ("/" not in r and r in VIETATI_ALLA_RADICE)
         or r.endswith(VIETATI_SUFFISSI)
         or any(r.startswith(c) or f"/{c}" in r for c in VIETATE_CARTELLE)
     ]

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,174 @@
+# `tools/` — the rules, in a form that can be run
+
+`CONTRIBUTING.md` and `AGENTS.md` say what this project expects. This directory is the
+same thing written so a machine can check it before something irreversible happens.
+
+It arrives here because @drake69 asked for it on
+[#25](https://github.com/chery-connect-ha/omoda9-ha/pull/25#issuecomment-5395878567): a
+rule only one machine can enforce is a rule the other three of us are guessing at. He also
+said the interesting half is the checklist rather than the shell, and he is right — the
+table below is the part that ports without change.
+
+**Nothing here is required.** `git push` and `gh pr create`, as written in `AGENTS.md`, work
+fine and always will. These scripts just refuse to let you forget something.
+
+## What each one does
+
+| | |
+|---|---|
+| `rules.sh` | the rulebook itself: `list`, `check` (read-only preflight), `log`. Also the library the other two load |
+| `pr.sh` | land a change: branch, gates in order, push, pull request filled from the repository's template |
+| `release.sh` | `status` · `prepare` (version bump + pull request) · `publish` (archive, tag, release, zip — only on green CI) · `abort` |
+| `check-secrets.sh` | every confidential pattern, across the **whole history** and the working tree, including files git has never seen |
+
+A pre-release from a pull request is the `beta` label, never a script.
+
+## Quick start
+
+```bash
+gh auth login                       # or: export GH_TOKEN=...
+./tools/rules.sh list               # the 26 rules, with sources
+./tools/rules.sh check              # read-only: what would stop you right now
+./tools/pr.sh "fix: what changed and why"
+```
+
+`check-secrets.sh` also wants a file that is **not** in this repository and never can be:
+
+```bash
+cp tools/private-patterns.example.txt tools/private-patterns.txt   # gitignored
+```
+
+Put your own name, your own paths and your own machine names in there. They are exactly
+the strings the checker exists to catch, so writing them into a tracked file publishes
+them — and the checker would not even notice, because a regex written with backslashes
+does not match itself. That is not a hypothetical: the author's e-mail address sat inside
+this tool for months, in the line meant to protect it.
+
+## The gate, and what it honestly is
+
+A failing gate stops the script. Past it there are two doors:
+
+- **a person at a terminal** — the dialogue runs on `/dev/tty`, you type a phrase
+  containing a one-time code printed at that moment, and you write a reason of at least
+  20 characters. It goes into `DEROGATIONS.log`, and if that file cannot be written the
+  derogation is not granted;
+- **`--authorized "<what you were told>"`, for agents** — most of us drive a coding agent,
+  and an agent has no terminal. Without this, every failing gate is a wall with no
+  recourse, and a tool that only works when everything is already green is a tool nobody
+  uses. It opens **only for NORMAL-severity rules**, and the sentence is recorded word for
+  word.
+
+There is a third flag in the same spirit. `pr.sh --evidence backend|not-mine|none` lets a
+script state what the evidence is, instead of falling back to `unverified-hardware` because
+nobody was at a terminal — which would put a false line in the next release notes for a
+change that touches no runtime behaviour at all. It deliberately **cannot** say *verified
+on hardware*: that answer means somebody watched a car, and nothing running without a
+person present is in a position to say so. The three it does accept can only ever weaken a
+claim.
+
+**What this is not.** No local mechanism can tell a person apart from a program that sees
+the same terminal — `script -qec`, `expect` and `tmux send-keys` can all read the one-time
+code and type it back. What is actually guaranteed is that a derogation cannot happen *by
+accident*, and that every one leaves a written line or does not happen. That is a high
+kerb and an honest register, not a wall. Anyone who calls it unbypassable is doing the
+thing this project forbids in writing: claiming a check they do not have.
+
+`--authorized` is weaker still, and says so: the script cannot verify that anybody
+authorised anything. What it does is make the claim explicit and permanent.
+
+## The 26 rules
+
+**HIGH** = the damage leaves this room and reaches somebody who is not in it.
+**NORMAL** = the damage stays at home.
+
+A source marked **house rule** has no prose behind it in this repository. It is the
+practice of the maintainer who wrote these scripts, kept because the gate is useful — not
+something the group has agreed. They are marked rather than smuggled in, and they are open
+to argument like everything else.
+
+| | | Rule | Source | Gate |
+|---|---|---|---|---|
+| **R01** | HIGH | Never push to `master` — everything lands as a pull request | `CONTRIBUTING.md` *Never*; `AGENTS.md` *The commands*; branch protection | blocks |
+| **R02** | HIGH | Never a secret: VIN, token, certificate, `tUserId`, account id, e-mail, phone, raw capture | `CONTRIBUTING.md` *Never*; `AGENTS.md` *Invariants*; `SECURITY.md` | blocks (`check-secrets.sh`, after the commit, before the push) |
+| **R03** | HIGH | CI green on the **exact** commit being published | `CONTRIBUTING.md` *It lands*; branch protection | blocks |
+| **R04** | HIGH | Changelog written for non-programmers, in both languages, never `--generate-notes` | **house rule** — and `AGENTS.md` *Cutting a release* currently suggests the opposite | blocks |
+| **R05** | HIGH | At most one stable release every two weeks | **house rule**, from measured history (45 releases in 30 days) | blocks |
+| **R06** | NORMAL | Shared code asks for a read by somebody who is not the author | `CONTRIBUTING.md` *It lands* | **warns** — the source says merging is never blocked |
+| **R07** | HIGH | Never claim a hardware check you do not have; the unverified gets **named** | `CONTRIBUTING.md`; `AGENTS.md`; `docs/field-test.md` | asks, and labels `unverified-hardware` |
+| **R08** | HIGH | No stable release without the `omoda9.zip` asset | `AGENTS.md` *Cutting a release*; `hacs.json` | blocks — archive built and validated **before** the tag |
+| **R09** | HIGH | No force-push, no rewriting published history | `AGENTS.md` *Never*; branch protection | blocks |
+| **R10** | NORMAL | No AI co-authorship trailers in commits | `AGENTS.md` *Save the work* | blocks |
+| **R11** | NORMAL | No Home Assistant imports inside `core/` | `AGENTS.md` *Invariants* | blocks |
+| **R12** | HIGH | Fail open; never take away an entity or a command that worked | `AGENTS.md` *Invariants*; `tests/test_entity_count.py` | blocks on a red suite; **warns** when there is no local interpreter, as `AGENTS.md` allows |
+| **R13** | NORMAL | One behaviour per pull request | `CONTRIBUTING.md` *Keep changes small* | warns |
+| **R14** | NORMAL | Private material stays out of the repository | `CONTRIBUTING.md` *Never*; `SECURITY.md` | blocks; again before every `git add`; and it checks git is not silently *ignoring* `tools/` |
+| **R15** | HIGH | Never send a command to a car without the owner's explicit go-ahead | **house rule** for agent-driven work | none — it is for the person, not the script |
+| **R16** | NORMAL | Never cut a release in order to test: that is what `beta` is for | `AGENTS.md`; `CONTRIBUTING.md`; `.github/workflows/beta.yml` | none |
+| **R17** | NORMAL | The repository is the source of truth, never the installed copy | **house rule** (generalises to any HA integration) | none |
+| **R18** | NORMAL | After publishing, tell the car owner the next step is theirs | **house rule** | none |
+| **R19** | HIGH | Before a **stable**, a field test for every model in the blast radius | `CONTRIBUTING.md` *It becomes stable* — *"the only real gate"* | blocks |
+| **R20** | NORMAL | A read is promised within a week, then `merged-unread` | `CONTRIBUTING.md` *The one-week rule* | none |
+| **R21** | HIGH | No model names as code paths | `AGENTS.md` *Invariants* | blocks |
+| **R22** | HIGH | The token is never committed nor left in `.git/config` | derived from `AGENTS.md` *Invariants*; `SECURITY.md` | blocks |
+| **R23** | HIGH | `manifest.json` already matches the tag | `AGENTS.md` *Cutting a release* | blocks |
+| **R24** | NORMAL | After an update: HA `RUNNING`, the entity count the test asserts, none unavailable | `tests/test_entity_count.py`; the inspection itself is a **house rule** | none |
+| **R25** | HIGH | Say **who** did the work a claim rests on: a person, or an agent they drive | `CONTRIBUTING.md` *Never*, merged in [#28](https://github.com/chery-connect-ha/omoda9-ha/pull/28); @drake69's convention in [#7](https://github.com/chery-connect-ha/omoda9-ha/issues/7) | asks and records — it cannot verify |
+| **R26** | HIGH | Re-read the thread before publishing a reply: somebody may have written since you drafted | a real mistake on 2026-08-24 | **not here** — it lives in the maintainer's local drafting tool |
+
+Two of those deserve a footnote.
+
+**R04 and R05 are house rules with blocking gates.** That combination is deliberate but it
+is the most arguable thing in this directory: a bilingual changelog and a two-week cadence
+are this maintainer's practice, and if you are cutting a release they will stop you. If the
+group wants them, they belong in `CONTRIBUTING.md` as prose, and that is a separate pull
+request. If the group does not want them, delete the gates.
+
+**R25 asks, it does not verify.** No program knows who really read a file. The gate
+recognises explicit first person ("I checked", "ho verificato") and, when the text does not
+say whose work it is, makes you answer and writes the answer at the bottom. It deliberately
+ignores impersonal forms ("Verified: 107 entities"), which are ambiguous by construction
+and would produce enough false positives to teach everyone to ignore the warning. Measured
+on the real material before adopting it: three lines in a 97 KB `CHANGELOG.md`, one in two
+hundred commit messages.
+
+### What `check-secrets.sh` will not catch
+
+Measured, not assumed. The allowance that stops fixtures failing the gate is shared by
+every pattern and filters by **line**, so any line containing the word `example` is exempt
+from all of them: a real address pasted as `someone@example.com` goes through. The phone
+shapes lean Italian, so a UK or Danish number is only caught by the international form.
+And the whole thing is regex over text — it recognises the shapes it was told about, and
+nothing else.
+
+It is written down because a checker people trust more than it deserves is worse than no
+checker at all.
+
+## What is deliberately not here
+
+- **A comment tool.** The maintainer has one, and it stays local: its distinguishing
+  feature is a mandatory summary in Italian for a car owner who does not read code and
+  should not approve English text blind. That is one person's problem, not the project's.
+  R26 is its rule, which is why R26 is listed above with no gate rather than quietly
+  dropped — a hole in the numbering would be more confusing than an honest line.
+- **A deploy script.** It copies the component into one particular Home Assistant VM. The
+  channel is HACS (R16); a fallback shaped around one person's virtualisation setup is not
+  worth publishing.
+
+## Portability, stated rather than discovered
+
+- **Fork or upstream.** `pr.sh` pushes to `origin` and opens the pull request against the
+  upstream repository, using `owner:branch` as the head when they differ. Set
+  `OMODA9_REPO` if you work against a different upstream. A beta build is never cut from a
+  fork.
+- **Python.** Home Assistant needs 3.13+. The suite gate looks at `$VIRTUAL_ENV`, then
+  `.venv/`, `.venv-test/`, `venv/`, `env/` inside the checkout, then
+  `python3.14`/`python3.13`/`python3`. If none of them has pytest, it says so
+  and lets CI be the gate — and the pull request body says the suite did not run locally.
+  The interpreter is deliberately **not** settable from the environment: that variable was
+  once the shortcut that made the suite gate pass without running a test.
+- **macOS/BSD.** `grep -oP`, `sed -i` without a suffix, `base64 -w0` and `date -Is` are all
+  GNU-only and none of them is used any more. If you find another, it is a bug.
+- **`zip(1)` is not assumed.** The release archive is built by python, and validated before
+  anything is tagged. It used to be built after the release was created, on a host with no
+  `zip` — which produced a published release with no asset, exactly what R08 calls worse
+  than no release at all.

--- a/tools/check-secrets.sh
+++ b/tools/check-secrets.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# tools/check-secrets.sh — proof that no confidential data is, or ever has been, tracked
+# in git. This repository is public: what goes in stays in, and a commit that is deleted
+# from a branch is still reachable from the reflog and from anybody's fork.
+#
+# It scans the WHOLE history, not just HEAD, and the working tree as well — including
+# files git has never seen, because the case this gate exists to catch is a note somebody
+# has just written and not yet added.
+#
+# It contains NO secrets itself. Structural patterns are generic; anything specific to one
+# person or one machine (a surname inside an e-mail, home paths, the names of private
+# infrastructure) is read from tools/private-patterns.txt, which is gitignored. Writing
+# those here would publish exactly what they exist to catch.
+#
+# Usage:  ./tools/check-secrets.sh
+# Exit:   0 = PASS (nothing found)   ·   1 = FAIL (found something, do NOT publish)
+#         2 = cannot run (not a git working tree, git missing)
+set -uo pipefail
+
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+command -v git >/dev/null || { echo "git is missing"; exit 2; }
+ROOT="$(git -C "$TOOLS_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
+[ -n "$ROOT" ] || { echo "not inside a git working tree"; exit 2; }
+cd "$ROOT"
+PRIVATE_PATTERNS="$TOOLS_DIR/private-patterns.txt"
+
+RED=$'\e[31m'; GRN=$'\e[32m'; YEL=$'\e[33m'; NC=$'\e[0m'
+fail=0; warn=0
+hit()  { echo "${RED}x FAIL${NC} $1"; fail=1; }
+ok()   { echo "${GRN}+${NC} $1"; }
+note() { echo "${YEL}!${NC} $1"; warn=1; }
+# A warning must mean "something to look at". Two of the inputs are optional local files,
+# and a fresh clone legitimately has neither: reporting their absence as a warning would
+# make every single run end in "PASS with warnings", which teaches people to stop reading
+# the warnings that matter.
+info() { echo "${YEL}i${NC} $1"; }
+
+# ⚠️ Patterns below are written so they cannot match THEMSELVES. `[/]root/` matches the
+# path but the literal text "[/]root/" does not, so this file does not permanently trip
+# its own gate. (Before this, every run reported five hits inside the tooling itself and
+# the result was "PASS with warnings" forever — a warning that always fires is a warning
+# people learn to ignore.)
+
+echo "== 1) Confidential files tracked NOW (HEAD) =="
+TRACKED=$(git ls-files | grep -iE '(^|/)(omoda9\.env|\.mqtt_cred|token\.json|private-patterns\.txt)$|/certs_eu/|\.pem$|\.key$|(^|/)data/|_diag\.jsonl' | grep -v 'example' || true)
+if [ -n "$TRACKED" ]; then hit "confidential files are tracked:"; echo "$TRACKED"; else ok "no confidential file tracked now"; fi
+
+echo "== 2) Confidential files tracked IN THE PAST (whole history) =="
+HIST=$(git log --all --pretty=format: --name-only --diff-filter=A 2>/dev/null | sort -u \
+       | grep -iE '(^|/)(omoda9\.env|\.mqtt_cred|token\.json|private-patterns\.txt)$|/certs_eu/|\.pem$|\.key$|(^|/)data/|_diag\.jsonl' \
+       | grep -v 'example' || true)
+if [ -n "$HIST" ]; then hit "confidential files present in past commits (exposed the moment anyone clones):"; echo "$HIST"; else ok "no confidential file anywhere in the history"; fi
+
+echo "== 3) Real values from your local env file, searched across the WHOLE history =="
+# omoda9.env is gitignored and holds this installation's real values. They are the only
+# ones no generic pattern can recognise. Loaded in a subshell and never printed.
+if [ ! -f omoda9.env ]; then
+  info "omoda9.env absent (normal unless you run the integration from this checkout):
+    the exact-value match on your own PIN, VIN, tUserId and phone number is not running."
+else
+  set -a; . ./omoda9.env 2>/dev/null || true; set +a
+  ALLREV=$(git rev-list --all 2>/dev/null)
+  checkval() { # $1=name $2=value
+    local name="$1" val="$2"
+    [ -z "$val" ] && return 0
+    [ "${#val}" -lt 4 ] && return 0   # too short -> false positives
+    # ⚠️ History AND working tree, and `--untracked` in BOTH places. This gate runs before
+    # the commit, so history alone lets through exactly what is about to be published; and
+    # without `--untracked` git grep only looks at files it already knows, while the case
+    # to catch is a NEW file. A real PIN pasted into a brand-new test file — which is what
+    # happened on 2026-08-02 — would have gone through untouched.
+    if { git grep -I -n -F "$val" $ALLREV -- . 2>/dev/null
+         git grep -I -n -F --untracked "$val" -- . 2>/dev/null; } | head -1 | grep -q .; then
+      hit "the value of $name appears in git (history or working tree)"
+    else
+      ok "$name: no match"
+    fi
+  }
+  # Only genuinely secret values. Usernames are not secrets and produce false positives.
+  for k in OMODA_EMAIL OMODA_PHONE OMODA_PIN PIN TUSERID VIN HA_MQTT_PASS; do
+    checkval "$k" "$(eval echo "\${$k:-}")"
+  done
+fi
+
+echo "== 4) Structural patterns across the WHOLE history =="
+ALLREV=${ALLREV:-$(git rev-list --all 2>/dev/null)}
+_scan() {
+  git grep -I -nE "$1" $ALLREV -- . 2>/dev/null
+  git grep -I -nE --untracked "$1" -- . 2>/dev/null
+}
+genpat() { # $1=description $2=regex $3=(optional) extra allowance, THIS pattern only
+  # The extra allowance is per-pattern and NOT global: widening the shared allowlist would
+  # also soften the checks on tokens, PEM keys and e-mail, which must stay strict.
+  # NB the allowlist filters by LINE -> the marker (VIN_PLACEHOLDER, PHONE_PLACEHOLDER)
+  # must be on the same line as the value, not in a comment above it.
+  # ⚠️ KNOWN BLIND SPOT, measured rather than assumed: the base allowance below is shared
+  # by every pattern, so ANY line containing the word "example" is exempt from all of
+  # them. A real address pasted as `someone@example.com` goes through. It is the price of
+  # not failing on every fixture, and it is written here so nobody mistakes the gate for
+  # more than it is.
+  local skip='example|placeholder|REPLACE_ME|FAKE_|VIN_PLACEHOLDER|PHONE_PLACEHOLDER'
+  [ -n "${3:-}" ] && skip="$skip|$3"
+  if _scan "$2" | grep -v -iE "$skip" | head -1 | grep -q .; then
+    hit "$1 (pattern: $2)"
+    _scan "$2" | grep -v -iE "$skip" | head -3
+  else ok "no match: $1"; fi
+}
+genpat "GitHub token"            'gh[pousr]_[A-Za-z0-9]{20,}'
+genpat "private key PEM"         'BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY'
+# The suite's synthetic VINs start with LZZ (tests/fixtures.py). Only that family is
+# allowed through: the exact-value check on the real VIN (section 3) is untouched and is
+# the one that counts. Reason for the allowance: the allowlist works by LINE, and a test
+# line carrying a fake VIN without the VIN_PLACEHOLDER marker failed the gate.
+genpat "VIN-shaped (L + 16)"     '\bL[A-HJ-NPR-Z0-9]{16}\b'  '\bLZZ[A-HJ-NPR-Z0-9]{14}\b'
+genpat "tUserId (long numeric)"  '\b3660[0-9]{14,}\b'
+genpat "JWT"                     '\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}'
+# ── Phone numbers (since v1.8: SMS login carries them into code, tests and logs) ──
+# A phone number is personal data exactly as an e-mail is. Several shapes, because whoever
+# pastes one from a real session writes it bare, with a country code, or with separators.
+# For a FAKE number in a test use tests/fixtures.py (FX.PHONE), never a literal.
+# ⚠️ These shapes are Italian-leaning. A UK or Danish number is caught only by the
+# international form: if you contribute from another country, add your own local shape to
+# tools/private-patterns.txt.
+genpat "bare Italian mobile"     '\b3[0-9]{9}\b'
+genpat "phone with +39"          '(\+|00)39[ ._-]?3[0-9]{2}[ ._-]?[0-9]{3}[ ._-]?[0-9]{4}'
+genpat "phone with separators"   '\b3[0-9]{2}[ .-][0-9]{3}[ .-][0-9]{3,4}\b'
+genpat "international phone"     '\+[1-9][0-9]{1,3}[ .-]?[0-9]{6,12}\b'
+
+echo "== 4b) Your own patterns (tools/private-patterns.txt) =="
+if [ ! -f "$PRIVATE_PATTERNS" ]; then
+  info "tools/private-patterns.txt absent: your name, your paths and your machine names are NOT being checked."
+  echo "    Copy tools/private-patterns.example.txt to tools/private-patterns.txt and fill it in."
+else
+  n=0
+  while IFS='|' read -r desc pat; do
+    case "$desc" in ''|'#'*) continue ;; esac
+    [ -n "$pat" ] || continue
+    n=$((n+1))
+    genpat "$desc" "$pat"
+  done < "$PRIVATE_PATTERNS"
+  [ "$n" -gt 0 ] || info "tools/private-patterns.txt is empty."
+fi
+
+echo "== 5) .gitignore consistency (the rules have to be there) =="
+for pat in 'omoda9.env' 'certs_eu/' 'token.json' '.mqtt_cred' 'data/' '*_diag.jsonl' 'DEROGATIONS.log' 'tools/private-patterns.txt'; do
+  grep -qF "$pat" .gitignore 2>/dev/null && ok ".gitignore covers '$pat'" \
+    || hit ".gitignore does NOT cover '$pat'"
+done
+# and: if the confidential files exist here, they must actually be ignored
+for f in omoda9.env token.json .mqtt_cred tools/private-patterns.txt $(ls -1 *_diag.jsonl 2>/dev/null); do
+  if [ -e "$f" ]; then
+    git check-ignore -q "$f" && ok "$f present and genuinely ignored" \
+      || hit "$f present but NOT ignored by git"
+  fi
+done
+
+echo "== 6) Soft info-disclosure (not secrets, but a leak in a public repository) =="
+# Warning, not failure. Patterns are self-avoiding (see the note at the top).
+SOFT='\b(10|192[.]168|172[.](1[6-9]|2[0-9]|3[01]))[.][0-9]{1,3}[.][0-9]{1,3}\b|[/]ro{2}t/|[/]home/[a-z_][a-z0-9_-]*/|[/]Users/[A-Za-z]|qm guest e[x]ec|pct e[x]ec|\bVM[I]D\b'
+# One allowance, and only one: `/root/.local/...` is where pip puts a package INSIDE the
+# Home Assistant container. It is documentation about Home Assistant, not about anybody's
+# machine, and without this the check would report it forever — a warning that always
+# fires is a warning people learn to ignore.
+SOFT_OK='[/]ro{2}t/\.local'
+SOFTHITS=$(git grep -nIE "$SOFT" -- '*.md' '*.py' '*.sh' '*.yml' '*.yaml' 2>/dev/null | grep -cvE "$SOFT_OK")
+if [ "$SOFTHITS" -gt 0 ]; then
+  note "$SOFTHITS internal references (private IPs, home paths, virtualisation commands) in tracked files:"
+  git ls-files '*.md' '*.py' '*.sh' '*.yml' '*.yaml' | while read -r f; do
+    n=$(grep -E "$SOFT" "$f" 2>/dev/null | grep -cvE "$SOFT_OK")
+    [ "${n:-0}" -gt 0 ] && echo "    $n  $f"
+  done
+  echo "    -> these say what your machine looks like. Scrub them before they are merged:"
+  echo "       once on GitHub they are public forever, in the history as well."
+else
+  ok "no internal reference in tracked files"
+fi
+
+echo "-----------------------------------------------"
+if [ "$fail" = "1" ]; then
+  echo "${RED}RESULT: FAIL - do not push. Clean the history and ROTATE whatever leaked.${NC}"
+  exit 1
+elif [ "$warn" = "1" ]; then
+  echo "${YEL}RESULT: PASS with warnings - read the '!' lines above before going on.${NC}"
+  exit 0
+else
+  echo "${GRN}RESULT: PASS - no secret in HEAD or in the history.${NC}"
+  exit 0
+fi

--- a/tools/pr.sh
+++ b/tools/pr.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# tools/pr.sh — the way a change lands in this repository.
+#
+#   ./tools/pr.sh "<commit message>"                    # branch inferred from the message
+#   ./tools/pr.sh -b fix/name-of-the-behaviour "<msg>"  # explicit branch
+#   ./tools/pr.sh --continue                            # branch and commit already made
+#   ./tools/pr.sh --draft ...                           # open the pull request as a draft
+#   ./tools/pr.sh --authorized "<what you were told>" ...   # for agents, see below
+#   ./tools/pr.sh --evidence none ...          # backend | not-mine | none — never "hardware"
+#
+# `master` is protected and the rules say every change goes through a pull request,
+# including from the people who wrote the rules. This script is where the gates in
+# rules.sh run IN ORDER — and the order is itself a rule: the secret gate runs AFTER the
+# commit and BEFORE the push, because against staged-only changes it sees nothing.
+#
+# You do not have to use this. `git push` and `gh pr create` are in AGENTS.md and work
+# fine. This just refuses to let you forget something.
+set -uo pipefail
+_HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$_HERE/rules.sh"
+cd "$R_ROOT"
+rules_cmdline "$@"
+
+R_REPO="${OMODA9_REPO:-chery-connect-ha/omoda9-ha}"
+BASE="master"
+
+BRANCH=""; MSG=""; CONTINUE=0; DRAFT=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -b|--branch)   BRANCH="${2:?}"; shift 2;;
+    --continue)    CONTINUE=1; shift;;
+    --draft)       DRAFT=1; shift;;
+    --authorized)  R_AUTHORIZED="${2:?the sentence with which you were given the go-ahead}"; shift 2;;
+    --evidence)    R_EVIDENCE_KIND="${2:?one of: backend | not-mine | none}"; shift 2;;
+    -h|--help)     sed -n '2,16p' "$0"; exit 0;;
+    -*)            _die "unknown option: $1 (a misspelled flag used to become the commit message)";;
+    *)             [ -z "$MSG" ] || _die "two commit messages: '$MSG' and '$1'. One only, in quotes.";
+                   MSG="$1"; shift;;
+  esac
+done
+_no_shortcuts
+R_TOKEN="$(rules_token)"
+[ -n "$R_TOKEN" ] || _die "no GitHub token. Set GH_TOKEN, or run 'gh auth login' once."
+
+printf '%s== pr.sh - landing a change under the rules ==%s\n\n' "$R_BOLD" "$R_NC"
+
+# ── 0. starting state ──────────────────────────────────────────────────────────────
+gate_tools
+git fetch -q origin "$BASE" || warn "fetch failed: working against the local origin/$BASE ref"
+gate_private_material_out
+gate_tools_visible
+
+# ── 1. R01 · never on master ───────────────────────────────────────────────────────
+BR_NOW="$(git rev-parse --abbrev-ref HEAD)"
+case "$(printf '%s' "$BR_NOW" | tr 'A-Z' 'a-z')" in
+  master|main)
+    [ "$CONTINUE" = "0" ] || require R01 "--continue from '$BR_NOW': there is no branch to push that is not master."
+    if [ -z "$BRANCH" ]; then
+      # ⚠️ First line only: a message written the way the project asks (title, blank line,
+      # body) produced a multi-line branch name and the script died.
+      BRANCH="fix/$(export LC_ALL=C; printf '%s' "${MSG:-change}" | sed -n 1p | tr '[:upper:]' '[:lower:]' \
+        | sed 's/[^a-z0-9]\{1,\}/-/g; s/^-//; s/-$//' | cut -c1-40)"
+      # LC_ALL=C above: in a UTF-8 locale the [a-z] class also collates accented letters
+      # and they ended up in the branch name. And a message with no alphanumerics ("!!!")
+      # gave "fix/", which git rejects with an error that explains nothing.
+      [ "$BRANCH" = "fix/" ] && BRANCH="fix/change-$(date +%H%M%S)"
+    fi
+    printf "you are on '%s': moving the work onto %s%s%s (master stays untouched)\n" "$BR_NOW" "$R_BOLD" "$BRANCH" "$R_NC"
+    git switch -q -c "$BRANCH" 2>/dev/null || git switch -q "$BRANCH" 2>/dev/null \
+      || _die "cannot create branch $BRANCH"
+    ;;
+esac
+BR_NOW="$(git rev-parse --abbrev-ref HEAD)"
+gate_not_on_master
+
+# ── 2. commit ──────────────────────────────────────────────────────────────────────
+if [ "$CONTINUE" = "0" ] && [ -n "$(git status --porcelain)" ]; then
+  [ -n "$MSG" ] || _die "there are uncommitted changes but no commit message.
+       Write it for whoever runs 'git blame' in a year, not for yourself today."
+  gate_no_trailer "$MSG"
+  gate_stage_clean                  # R14 — before the git add, not after
+  git add -A
+  git commit -q --cleanup=verbatim -m "$MSG" || _die "commit failed"
+  ok "commit made"
+fi
+gate_no_trailer_in_commits "origin/$BASE"
+
+NEW_COMMITS="$(git rev-list --count "origin/$BASE"..HEAD)"
+[ "$NEW_COMMITS" -gt 0 ] || _die "no commit beyond origin/$BASE: there is nothing to propose."
+
+# ── 3. gates on the content ────────────────────────────────────────────────────────
+gate_core_without_ha            # R11
+gate_no_model_names             # R21
+gate_suite                      # R12
+gate_secrets                    # R02 + R22 — after the commit, before the push
+gate_shared_code "origin/$BASE" # R06 — a warning, not a block
+
+FILE_N="$(git diff --name-only "origin/$BASE"...HEAD | wc -l)"
+if [ "$FILE_N" -gt 12 ] || [ "$NEW_COMMITS" -gt 8 ]; then
+  warn "R13 · $FILE_N files, $NEW_COMMITS commits: a change nobody can read is not reviewable."
+  warn "     If these are separate behaviours, open them one at a time. (Judgement, not a measurement: not stopping you.)"
+fi
+
+# ── 4. R07 · the evidence declaration ──────────────────────────────────────────────
+R_EVIDENCE=""; R_LABELS=""
+gate_field_test
+
+# ── 4b. R25 · whose work is it that this text claims ───────────────────────────────
+# R07 says what a piece of evidence is worth; R25 says WHO produced it. In a project where
+# none of us writes code by hand, "I read it" and "the agent I drive read it" are not the
+# same claim, and letting them blur makes a sentence weigh more than it earned.
+R_ATTRIBUTION=""
+gate_attribution "$(git log --format='%s%n%b' "origin/$BASE"..HEAD; printf '%s\n' "$R_EVIDENCE")"
+
+# ── 5. push the BRANCH ─────────────────────────────────────────────────────────────
+printf '%s==> pushing %s%s\n' "$R_BLUE" "$BR_NOW" "$R_NC"
+# push_safe gets the REAL arguments (R01/R09 inspect them normalised) and authenticates
+# with an ephemeral header: no URL carrying the token, so no token in .git/config (R22).
+push_safe origin "HEAD:refs/heads/$BR_NOW" || _die "push failed.
+       No force, on purpose: if the branch has diverged, 'git fetch origin && git merge origin/$BASE'."
+git fetch -q origin "$BR_NOW" 2>/dev/null && git branch -q --set-upstream-to="origin/$BR_NOW" 2>/dev/null || true
+ok "branch pushed to origin"
+
+# Where the branch actually landed. If `origin` is your own fork, the pull request still
+# has to be opened against the upstream repository, and the API then wants `owner:branch`
+# as the head — with a bare branch name it answers "No commits between ..." and the run
+# ends with the work pushed and no pull request.
+ORIGIN_URL="$(git remote get-url origin 2>/dev/null || true)"
+ORIGIN_SLUG="$(printf '%s' "$ORIGIN_URL" | sed -E 's#^(https://[^/]+/|git@[^:]+:)##; s#\.git$##')"
+# ⚠️ Only treat it as a slug if it actually looks like one. A remote that is a local path
+# ("../mirror.git") left `${ORIGIN_SLUG%%/*}` as ".." and the head became "..:branch".
+# Found by running this against a sandbox remote, not by reading it.
+printf '%s' "$ORIGIN_SLUG" | grep -qE '^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$' || ORIGIN_SLUG=""
+HEAD_REF="$BR_NOW"
+if [ -n "$ORIGIN_SLUG" ] && [ "$ORIGIN_SLUG" != "$R_REPO" ]; then
+  HEAD_REF="${ORIGIN_SLUG%%/*}:$BR_NOW"
+  warn "origin is $ORIGIN_SLUG, not $R_REPO: opening the pull request from a fork ($HEAD_REF)."
+  echo "      Note: a beta build is never cut from a fork — a member publishes it by hand."
+fi
+
+# ── 6. the pull request ────────────────────────────────────────────────────────────
+TITLE="$(printf '%s' "${MSG:-$(git log -1 --format=%s)}" | head -1)"
+BODY_F="$(mktemp)"; trap 'rm -f "$BODY_F" "${PAYLOAD:-}" "${RESP:-}"' EXIT
+TEMPLATE=".github/PULL_REQUEST_TEMPLATE.md"
+if [ -f "$TEMPLATE" ]; then
+  # The repository's template is the shape reviewers expect: fill it in, do not replace it
+  # with an invention of your own.
+  {
+    echo "## What changes, and why"; echo
+    git log --reverse --format='- %s' "origin/$BASE"..HEAD
+    echo; echo "## Evidence"; echo
+    echo "${R_EVIDENCE:-not declared}"
+    [ -n "${R_ATTRIBUTION:-}" ] && { echo; echo "${R_ATTRIBUTION}"; }
+    echo; echo "## Checks"; echo
+    if [ "${R_SUITE_SKIPPED:-0}" = "1" ]; then
+      echo "- [ ] Suite green — **not run locally**: no interpreter with pytest on this machine, CI is the gate (\`AGENTS.md\`)"
+      echo "- [ ] Entity count unchanged — same, checked by CI"
+    else
+      echo "- [x] Suite green (\`pytest tests/ -q\`) — R12 gate in \`tools/pr.sh\`"
+      echo "- [x] Entity count unchanged — \`tests/test_entity_count.py\`, inside the suite"
+    fi
+    echo "- [x] No VIN, token, certificate, account id or raw capture — R02 gate (\`tools/check-secrets.sh\`, whole history)"
+    echo "- [ ] Fails open: nothing here can take away a function that worked for somebody"
+    echo "- [ ] Design docs updated if this contradicts them"
+  } > "$BODY_F"
+else
+  { git log --reverse --format='- %s' "origin/$BASE"..HEAD; echo; echo "${R_EVIDENCE:-not declared}"
+    [ -n "${R_ATTRIBUTION:-}" ] && { echo; echo "${R_ATTRIBUTION}"; } || true; } > "$BODY_F"
+fi
+[ "${R_NEEDS_READ:-0}" = "1" ] && {
+  { echo; echo "## Read requested"; echo
+    echo "This touches shared code, so I am asking for a read from somebody who is not the author (R06)."
+    echo "The merge is not blocked: if the week elapses, I merge and label it \`merged-unread\` (R20)."
+  } >> "$BODY_F"; }
+
+printf '%s==> opening the pull request%s\n' "$R_BLUE" "$R_NC"
+PAYLOAD="$(mktemp)"; RESP="$(mktemp)"
+python3 - "$TITLE" "$BODY_F" "$HEAD_REF" "$BASE" "$DRAFT" > "$PAYLOAD" <<'PY'
+import json, sys
+t, f, head, base, draft = sys.argv[1:6]
+print(json.dumps({"title": t, "body": open(f, encoding="utf-8").read(),
+                  "head": head, "base": base, "draft": draft == "1"}))
+PY
+CODE="$(_curl_gh -s -o "$RESP" -w '%{http_code}' -X POST \
+        "https://api.github.com/repos/${R_REPO}/pulls" -d @"$PAYLOAD")"
+NUM="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get("number") or "")' "$RESP" 2>/dev/null || true)"
+if [ -z "$NUM" ]; then
+  NUM="$(_gh "pulls?head=$(printf '%s' "$HEAD_REF" | sed "s#^\([^:]*\)\$#${R_REPO%%/*}:\1#")&state=open" \
+        | python3 -c 'import json,sys;d=json.load(sys.stdin);print(d[0]["number"] if d else "")' 2>/dev/null || true)"
+  if [ -n "$NUM" ]; then
+    echo "    pull request #$NUM already open on this branch: updated by the push."
+  else
+    { echo "HTTP $CODE"; sed 's|^|  \| |' "$RESP"; echo
+      echo "The branch IS on GitHub: the work is not lost, only the pull request is missing."
+      echo "Open it by hand from:  https://github.com/${R_REPO}/compare/${BASE}...${BR_NOW}?expand=1"; } >&2
+    _die "could not open the pull request."
+  fi
+else
+  ok "pull request #$NUM opened"
+fi
+
+if [ -n "${R_LABELS:-}" ]; then
+  _curl_gh -s -o /dev/null -X POST "https://api.github.com/repos/${R_REPO}/issues/${NUM}/labels" \
+    -d "$(python3 -c 'import json,sys;print(json.dumps({"labels":sys.argv[1].split(",")}))' "$R_LABELS")"
+  echo "    label: $R_LABELS"
+fi
+
+echo
+printf '%shttps://github.com/%s/pull/%s%s\n\n' "$R_BOLD" "$R_REPO" "$NUM" "$R_NC"
+echo "Now: CI runs on the pull request."
+[ "${R_NEEDS_READ:-0}" = "1" ] && echo "Ask for the R06 read - but nobody is blocking the merge."
+echo "To get it onto a real car BEFORE it lands: put the 'beta' label on the pull request (R16),"
+echo "and whoever owns that car installs it from HACS with 'Show beta versions'."
+echo "Tags and releases are not made from here: './tools/release.sh prepare' then 'publish'."

--- a/tools/pr.sh
+++ b/tools/pr.sh
@@ -133,9 +133,24 @@ ORIGIN_SLUG="$(printf '%s' "$ORIGIN_URL" | sed -E 's#^(https://[^/]+/|git@[^:]+:
 printf '%s' "$ORIGIN_SLUG" | grep -qE '^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$' || ORIGIN_SLUG=""
 HEAD_REF="$BR_NOW"
 if [ -n "$ORIGIN_SLUG" ] && [ "$ORIGIN_SLUG" != "$R_REPO" ]; then
-  HEAD_REF="${ORIGIN_SLUG%%/*}:$BR_NOW"
-  warn "origin is $ORIGIN_SLUG, not $R_REPO: opening the pull request from a fork ($HEAD_REF)."
-  echo "      Note: a beta build is never cut from a fork — a member publishes it by hand."
+  # ⚠️ A different slug is not necessarily a fork. A repository that has been renamed or
+  # transferred keeps answering under its old name through a 301, and a remote URL left
+  # over from before the move is extremely common — this repository moved to an
+  # organisation and the maintainer's remote still said the old owner months later.
+  # Treating that as a fork sends `oldowner:branch` as the head and GitHub replies
+  # 422 "head invalid", with the branch already pushed and no pull request to show for it.
+  # Measured here, the first time this ran for real.
+  CANONICAL="$(_curl_gh -sL "https://api.github.com/repos/${ORIGIN_SLUG}" 2>/dev/null \
+               | python3 -c 'import json,sys;print(json.load(sys.stdin).get("full_name",""))' 2>/dev/null || true)"
+  if [ "$CANONICAL" = "$R_REPO" ]; then
+    warn "origin still says $ORIGIN_SLUG, which is an old name for $R_REPO."
+    echo "      Same repository, not a fork. Worth fixing so it stops surprising people:"
+    echo "        git remote set-url origin https://github.com/$R_REPO.git"
+  else
+    HEAD_REF="${ORIGIN_SLUG%%/*}:$BR_NOW"
+    warn "origin is $ORIGIN_SLUG, not $R_REPO: opening the pull request from a fork ($HEAD_REF)."
+    echo "      Note: a beta build is never cut from a fork — a member publishes it by hand."
+  fi
 fi
 
 # ── 6. the pull request ────────────────────────────────────────────────────────────

--- a/tools/pr.sh
+++ b/tools/pr.sh
@@ -154,7 +154,12 @@ if [ -n "$ORIGIN_SLUG" ] && [ "$ORIGIN_SLUG" != "$R_REPO" ]; then
 fi
 
 # ── 6. the pull request ────────────────────────────────────────────────────────────
-TITLE="$(printf '%s' "${MSG:-$(git log -1 --format=%s)}" | head -1)"
+# ⚠️ With --continue and no message, the title used to come from `git log -1`, i.e. the
+# LAST commit on the branch — which on a branch of several commits is the least
+# representative one. Measured on this very pull request: a two-line follow-up fix became
+# the title of the whole thing. The first commit beyond the base is what the branch is
+# about; the last one is usually a correction to it.
+TITLE="$(printf '%s' "${MSG:-$(git log --reverse --format=%s "origin/$BASE"..HEAD | head -1)}" | head -1)"
 BODY_F="$(mktemp)"; trap 'rm -f "$BODY_F" "${PAYLOAD:-}" "${RESP:-}"' EXIT
 TEMPLATE=".github/PULL_REQUEST_TEMPLATE.md"
 if [ -f "$TEMPLATE" ]; then

--- a/tools/private-patterns.example.txt
+++ b/tools/private-patterns.example.txt
@@ -1,0 +1,21 @@
+# tools/private-patterns.txt — extra secret patterns, specific to YOU or YOUR machine.
+#
+# Copy this file to tools/private-patterns.txt (which is gitignored) and fill it in.
+# check-secrets.sh treats every pattern here as BLOCKING, exactly like the built-in ones.
+#
+# Why it is a separate, ignored file: these patterns necessarily contain the very things
+# they exist to catch — your surname inside an e-mail address, the layout of your disk,
+# the hostnames of your network. Writing them into a tracked script publishes them, and
+# the script would not even notice, because a regex written with backslashes does not
+# match itself. That is not hypothetical: it is how the author's e-mail address sat in
+# this tool for months.
+#
+# Format:  description|extended regex     (one per line, '#' starts a comment)
+#
+# Examples — replace with your own, then delete these lines:
+#
+# my e-mail (any domain)|(john\.smith|j\.smith)@
+# my home directory|/home/john/
+# my machine names|\b(bluebird|the-attic-box)[0-9]*\b
+# my HA instance|\bha\.example\.lan\b
+# my UK mobile|\b07[0-9]{9}\b

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -1,0 +1,406 @@
+#!/usr/bin/env bash
+# tools/release.sh — cutting a release, in TWO acts, because `master` is protected.
+#
+#   ./tools/release.sh status                        where we are, touching nothing
+#   ./tools/release.sh prepare <X.Y.Z|patch|minor|major>
+#        Bumps the version in the manifest, dates the '[Non rilasciato]' section of the
+#        CHANGELOG, commits on 'release/vX.Y.Z' and opens the pull request. Never touches
+#        master.
+#   ./tools/release.sh publish [X.Y.Z]
+#        AFTER that pull request has been merged: checks CI is green on the exact commit,
+#        builds and VALIDATES the archive, then tags, creates the release, uploads the zip
+#        and names whatever nobody could try on a real car.
+#   ./tools/release.sh abort <X.Y.Z>                 undoes a bad 'prepare', locally only
+#
+# Options:  --authorized "<what you were told>"      for agents; NORMAL-severity rules only
+#
+# A pre-release from a pull request is the `beta` label, not this script (R16).
+set -uo pipefail
+_HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$_HERE/rules.sh"
+cd "$R_ROOT"
+rules_cmdline "$@"
+
+R_REPO="${OMODA9_REPO:-chery-connect-ha/omoda9-ha}"
+SRC_DIR="custom_components/omoda9"
+MANIFEST="$SRC_DIR/manifest.json"
+CHANGELOG="CHANGELOG.md"
+ZIP_NAME="omoda9.zip"        # must match "filename" in hacs.json
+BASE="master"
+UNRELEASED="## [Non rilasciato]"
+
+ARGS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --authorized) R_AUTHORIZED="${2:?the sentence with which you were given the go-ahead}"; shift 2;;
+    *)            ARGS+=("$1"); shift;;
+  esac
+done
+set -- "${ARGS[@]:-}"
+_no_shortcuts
+R_TOKEN="$(rules_token)"
+[ -n "$R_TOKEN" ] || _die "no GitHub token. Set GH_TOKEN, or run 'gh auth login' once."
+
+ACTION="${1:-status}"; shift || true
+
+# Everything transient in one directory, removed whatever happens.
+TMPD="$(mktemp -d)"; trap 'rm -rf "$TMPD"' EXIT
+
+# Only release tags: the pre-releases cut by beta.yml (vX.Y.Z-beta.N) are not published
+# versions. See R_TAG_RELEASE in rules.sh for why counting them does silent damage.
+_last_tag() { git for-each-ref --sort=-creatordate --format='%(refname:short)' refs/tags \
+                | grep -E "$R_TAG_RELEASE" | sed -n 1p; }
+
+# ⚠️ The changelog section is extracted by LITERAL prefix comparison, never by regex.
+# `awk '$0 ~ "^## v"NEW'` treated the dots as wildcards and did not anchor on the right:
+# with NEW=1.5.1 the release body swallowed v1.5.10...v1.5.19 as well — eleven versions
+# concatenated, and that text is what HACS shows to every user. The trailing space is the
+# right-hand anchor.
+_changelog_section() { # $1 = "## [Non rilasciato]" or "## v1.13.1"
+  awk -v v="$1 " 'index($0,v)==1 {f=1;next} /^## /{f=0} f' "$CHANGELOG" \
+    | sed '/./,$!d' | sed -e :a -e '/^[[:space:]]*$/{$d;N;ba' -e '}'
+}
+
+# ══════════════════════════════ STATUS ══════════════════════════════
+if [ "$ACTION" = "status" ]; then
+  printf '%sRelease status%s\n' "$R_BOLD" "$R_NC"
+  echo "  manifest:      $(manifest_version)"
+  echo "  last tag:      $(_last_tag)"
+  echo "  branch:        $(git rev-parse --abbrev-ref HEAD)"
+  git fetch -q origin "$BASE" --tags 2>/dev/null || true
+  echo "  remote master: $(git rev-parse --short "origin/$BASE" 2>/dev/null)"
+  echo
+  R_PREFLIGHT=1
+  ( gate_changelog ) || true
+  ( gate_cadence )   || true
+  echo
+  echo "Next:  ./tools/release.sh prepare <patch|minor|major|X.Y.Z>"
+  exit 0
+fi
+
+# ══════════════════════════════ ABORT ══════════════════════════════
+# This exists because an interrupted 'prepare' left the operator on a release branch with
+# the changes staged, and every retry died from there: a state the script itself refused
+# to start from. LOCAL only: it touches nothing on GitHub.
+if [ "$ACTION" = "abort" ]; then
+  V="${1:?usage: $0 abort X.Y.Z}"
+  git switch -q "$BASE" 2>/dev/null || true
+  git restore -q --staged --worktree . 2>/dev/null || true
+  git branch -qD "release/v$V" 2>/dev/null && echo "  branch release/v$V removed" || true
+  git tag -d "v$V" 2>/dev/null && echo "  local tag v$V removed" || true
+  ok "local state cleaned. Nothing on GitHub was touched."
+  exit 0
+fi
+
+# ══════════════════════════════ PREPARE ══════════════════════════════
+if [ "$ACTION" = "prepare" ]; then
+  printf '%s== release · act 1: preparing the pull request ==%s\n\n' "$R_BOLD" "$R_NC"
+  gate_tools
+  git fetch -q origin "$BASE" --tags || warn "fetch failed: working against local refs"
+  [ -z "$(git status --porcelain)" ] || _die "there are uncommitted changes. Land them first with ./tools/pr.sh:
+       a release is not the place to slip in unreviewed work."
+
+  # The current version is read from ORIGIN/MASTER: the release branch is cut from there,
+  # and a local manifest that is ahead would compute the wrong number.
+  git show "origin/$BASE:$MANIFEST" > "$TMPD/manifest.json"
+  CUR="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["version"])' "$TMPD/manifest.json")"
+  case "${1:-}" in
+    patch|minor|major)
+      IFS=. read -r MA MI PA <<<"$CUR"
+      case "$1" in patch) PA=$((PA+1));; minor) MI=$((MI+1)); PA=0;; major) MA=$((MA+1)); MI=0; PA=0;; esac
+      NEW="$MA.$MI.$PA" ;;
+    *) NEW="${1:-}" ;;
+  esac
+  # ⚠️ Real validation, not a glob: `[0-9]*.[0-9]*.[0-9]*` accepted `1.2.3&x`, and `&` in a
+  # sed replacement expands to the whole match — the manifest and the changelog came out
+  # of the attempt corrupted.
+  [[ "$NEW" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+    || _die "invalid version: '${NEW}'. Usage: $0 prepare <X.Y.Z | patch|minor|major>   (current: $CUR)"
+  git rev-parse -q --verify "refs/tags/v$NEW" >/dev/null && _die "tag v$NEW already exists."
+
+  printf '\n%s==> version: %s -> %s  (from origin/%s)%s\n' "$R_BLUE" "$CUR" "$NEW" "$BASE" "$R_NC"
+  BR="release/v$NEW"
+  BR_START="$(git rev-parse --abbrev-ref HEAD)"
+  # If we die halfway, go back where we started: no hybrid state, no release edits left
+  # staged and following the operator back onto master.
+  _restore() { git switch -q "$BR_START" 2>/dev/null || true
+               git restore -q --staged --worktree . 2>/dev/null || true
+               git branch -qD "$BR" 2>/dev/null || true; rm -rf "$TMPD"; }
+  trap _restore EXIT
+
+  if git rev-parse -q --verify "refs/heads/$BR" >/dev/null; then
+    git switch -q "$BR" || _die "cannot switch to $BR"
+    if [ "$(git rev-list --count "origin/$BASE".."$BR")" -gt 0 ]; then
+      warn "branch $BR already exists and has commits of its own: continuing on it."
+    else
+      git reset -q --hard "origin/$BASE"
+    fi
+  else
+    git switch -q -c "$BR" "origin/$BASE" || _die "cannot create branch $BR"
+  fi
+  gate_not_on_master
+
+  # The gates judge the content of the BRANCH, i.e. what will end up in the tag.
+  gate_private_material_out
+  gate_changelog "$UNRELEASED"
+  # R25 — while the text is still editable: who did what the changelog claims?
+  warn_attribution "$(_changelog_section "$UNRELEASED")" "the notes for this version"
+  gate_cadence "$NEW"
+  gate_core_without_ha
+  gate_no_model_names
+  gate_suite
+
+  # python, not sed: `sed -i` without a suffix is GNU-only and fails on macOS, and a JSON
+  # file deserves a JSON parser.
+  python3 - "$MANIFEST" "$NEW" <<'PY'
+import json, sys
+p, new = sys.argv[1], sys.argv[2]
+raw = open(p, encoding="utf-8").read()
+d = json.loads(raw)
+old = d["version"]
+# Rewrite only the version string, leaving key order and formatting exactly as they are:
+# hassfest checks the order of the keys in this file.
+i = raw.index('"version"')
+j = raw.index(old, i)
+open(p, "w", encoding="utf-8").write(raw[:j] + new + raw[j+len(old):])
+PY
+  python3 - "$CHANGELOG" "$NEW" "$(date +%Y-%m-%d)" "$UNRELEASED" <<'PY'
+import sys
+p, new, date, unreleased = sys.argv[1:5]
+lines = open(p, encoding="utf-8").read().split("\n")
+for i, l in enumerate(lines):
+    if l.startswith(unreleased):
+        lines[i:i+1] = [unreleased, "", f"## v{new} — {date}"]
+        break
+else:
+    raise SystemExit(f"heading {unreleased!r} not found in {p}")
+open(p, "w", encoding="utf-8").write("\n".join(lines))
+PY
+  gate_manifest_matches_tag "$NEW"
+  # Safety net: the section just dated must actually contain text.
+  _changelog_section "## v$NEW" | grep -qE '[[:alnum:]]' \
+    || require R04 "after dating it, section '## v$NEW' is empty: the text you read in the gate is not the text about to be tagged (work not yet merged into $BASE?)."
+
+  MSG="release: v$NEW"
+  gate_no_trailer "$MSG"
+  git add "$MANIFEST" "$CHANGELOG"
+  git commit -q --cleanup=verbatim -m "$MSG" || _die "commit failed"
+  gate_secrets                                    # R02 + R22, after the commit, before the push
+
+  push_safe origin "HEAD:refs/heads/$BR" || _die "pushing the branch failed"
+  trap 'rm -rf "$TMPD"' EXIT                      # from here on the branch must survive
+
+  BODY="$TMPD/pr.md"
+  { echo "Bumps the version to **v$NEW** and dates the changelog section HACS will show."
+    echo; echo "No code changes: only \`manifest.json\` and \`CHANGELOG.md\`."
+    echo; echo "## Evidence"; echo
+    echo "**No runtime behaviour** - nothing a user can see changes in this pull request."
+    echo; echo "Merge once CI is green, and **then** \`./tools/release.sh publish $NEW\` tags it,"
+    echo "creates the release and uploads \`$ZIP_NAME\`."; } > "$BODY"
+  RESP="$TMPD/pr.json"
+  _curl_gh -s -o "$RESP" -X POST "https://api.github.com/repos/${R_REPO}/pulls" \
+    -d "$(python3 -c 'import json,sys;print(json.dumps({"title":sys.argv[1],"body":open(sys.argv[2],encoding="utf-8").read(),"head":sys.argv[3],"base":sys.argv[4]}))' "$MSG" "$BODY" "$BR" "$BASE")"
+  NUM="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get("number") or "")' "$RESP" 2>/dev/null || true)"
+  echo
+  [ -n "$NUM" ] && ok "pull request https://github.com/${R_REPO}/pull/${NUM}" \
+                || warn "pull request not opened automatically: open it on GitHub from branch $BR"
+  echo
+  printf '%sNow:%s wait for the three green checks, merge the pull request, then:\n' "$R_BOLD" "$R_NC"
+  echo "   git switch $BASE && git pull && ./tools/release.sh publish $NEW"
+  echo "If something went wrong here:  ./tools/release.sh abort $NEW"
+  exit 0
+fi
+
+# ══════════════════════════════ PUBLISH ══════════════════════════════
+[ "$ACTION" = "publish" ] || _die "usage: $0 [status|prepare|publish|abort]"
+
+printf '%s== release · act 2: publishing ==%s\n\n' "$R_BOLD" "$R_NC"
+gate_tools
+git fetch -q origin "$BASE" --tags || warn "fetch failed"
+
+BR_NOW="$(git rev-parse --abbrev-ref HEAD)"
+[ "$BR_NOW" = "$BASE" ] || _die "you are on '$BR_NOW': a tag goes on $BASE, on the commit already merged.
+       git switch $BASE && git pull"
+[ -z "$(git status --porcelain)" ] || _die "dirty tree: what gets published is exactly what is on master, nothing more."
+SHA="$(git rev-parse HEAD)"
+[ "$SHA" = "$(git rev-parse "origin/$BASE")" ] || _die "your master is not the tip of origin/$BASE. 'git pull' and run again."
+
+NEW="${1:-$(manifest_version)}"
+[[ "$NEW" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || _die "invalid version: '$NEW'"
+gate_manifest_matches_tag "$NEW"                       # R23
+gate_private_material_out                              # R14
+gate_cadence "$NEW"                                    # R05, without counting the in-flight tag
+gate_ci_green "$SHA"                                   # R03, on the EXACT commit
+gate_secrets                                           # R02 + R22
+
+# ── R04 · the release body = the human changelog for THIS version ──────────────────
+NOTES="$TMPD/notes.md"
+_changelog_section "## v$NEW" > "$NOTES"
+grep -qE '[[:alnum:]]' "$NOTES" \
+  || require R04 "there is no '## v$NEW' section with text in the CHANGELOG: HACS would show an empty body."
+{ grep -q 'Italiano' "$NOTES" && grep -q 'English' "$NOTES"; } \
+  || require R04 "the notes for v$NEW are not bilingual."
+
+# ── R25 · do the notes say whose work they claim? ─────────────────────────────────
+# No block here: it names them, BEFORE anything becomes public. The gate that asks sits
+# where the text speaks to the team (pr.sh), not where it speaks to the end user.
+warn_attribution "$(cat "$NOTES")" "the body of release v$NEW"
+
+# ── R07 / R19 · evidence: an inventory of everything merged since the last tag ─────
+printf '%s==> R07/R19 · evidence inventory since the last tag%s\n' "$R_BLUE" "$R_NC"
+# ⚠️ Release tags only: a beta cut yesterday from a pull request would shorten this window
+# enough to leave out the very changes that must be named, and with an empty inventory the
+# R19 gate below would not fire at all.
+PREV="$(git for-each-ref --sort=-creatordate --format='%(refname:short) %(creatordate:unix)' refs/tags \
+        | grep -E "$R_TAG_RELEASE" \
+        | grep -v "^v${NEW} " | sed -n 1p | awk '{print $1}')"
+SINCE="$(git log -1 --format=%cI "$PREV" 2>/dev/null || echo '1970-01-01T00:00:00Z')"
+echo "    since tag ${PREV:-(none)} ($SINCE)"
+INV="$TMPD/inventory.tsv"
+# ⚠️ Paginate until we pass the date: a single page sorted by update time leaves out
+# precisely the oldest pull requests of the period, i.e. the ones most at risk of not
+# being named.
+: > "$TMPD/prs.json"
+PAGE=1
+while [ "$PAGE" -le 10 ]; do
+  _gh "pulls?state=closed&base=${BASE}&per_page=100&page=${PAGE}&sort=updated&direction=desc" > "$TMPD/p.json" || break
+  N="$(python3 -c 'import json,sys;print(len(json.load(open(sys.argv[1]))))' "$TMPD/p.json" 2>/dev/null || echo 0)"
+  cat "$TMPD/p.json" >> "$TMPD/prs.json"; printf '\n' >> "$TMPD/prs.json"
+  [ "$N" -lt 100 ] && break
+  PAGE=$((PAGE+1))
+done
+python3 - "$TMPD/prs.json" "$SINCE" > "$INV" <<'PY'
+import json, sys
+prs, seen = [], set()
+for block in open(sys.argv[1], encoding="utf-8").read().split("\n["):
+    b = block if block.startswith("[") else "[" + block
+    try: prs.extend(json.loads(b))
+    except Exception: pass
+since = sys.argv[2]
+for p in prs:
+    if p["number"] in seen: continue
+    seen.add(p["number"])
+    if not p.get("merged_at") or p["merged_at"] <= since: continue
+    labels = {l["name"] for l in p.get("labels", [])}
+    state = ("UNVERIFIED" if "unverified-hardware" in labels
+             else "VERIFIED" if any(l.startswith("verified:") for l in labels) else "SILENT")
+    print(f"{state}\t{p['number']}\t{p['title']}")
+PY
+UNVER="$(grep -c '^UNVERIFIED' "$INV" || true)"
+VER="$(grep -c '^VERIFIED' "$INV" || true)"
+SILENT="$(grep -c '^SILENT' "$INV" || true)"
+echo "    tried on a car: ${VER:-0} · not testable: ${UNVER:-0} · no declaration: ${SILENT:-0}"
+
+# Unlabelled pull requests do NOT block: no source asks for it, and a gate that fires on
+# every release only teaches people to derogate. They are named, and counted as unverified.
+if [ "${SILENT:-0}" -gt 0 ]; then
+  warn "R07 · ${SILENT} pull requests say nothing about evidence; treating them as unverified:"
+  grep '^SILENT' "$INV" | awk -F'\t' '{print "      #"$2" "$3}'
+fi
+if [ "${UNVER:-0}" -gt 0 ] || [ "${SILENT:-0}" -gt 0 ]; then
+  { echo; echo "---"; echo
+    echo "### 🇮🇹 Non provato su un'auto"
+    echo "In questa versione ci sono modifiche che **nessuno ha potuto provare su una vettura reale**:"
+    grep -E '^(UNVERIFIED|SILENT)' "$INV" | awk -F'\t' '{print "- #"$2" - "$3}'
+    echo
+    echo "### 🇬🇧 Not verified on hardware"
+    echo "This release contains changes **nobody was able to test on a real car**:"
+    grep -E '^(UNVERIFIED|SILENT)' "$INV" | awk -F'\t' '{print "- #"$2" - "$3}'
+  } >> "$NOTES"
+  warn "R07 · named in the release body, not hidden"
+fi
+# R19 — the only gate the sources call real.
+if [ "${VER:-0}" -eq 0 ] && [ "$(wc -l < "$INV")" -gt 0 ]; then
+  require R19 "none of the pull requests merged since the last tag carries a field test (verified:<model>).
+A stable release is a statement to strangers: it needs at least one report from somebody who owns the car,
+in the form of docs/field-test.md. To get one: put the 'beta' label on the pull request and ask."
+fi
+
+# ── R08 · the archive is built and VALIDATED BEFORE anything is tagged ─────────────
+# ⚠️ It used to tag, create the release, and only then build the zip — with `zip(1)`, which
+# is not installed everywhere. Measured in a sandbox: tag and release published, zero
+# assets, i.e. exactly what R08 calls "worse than no release". python always exists here,
+# and nothing becomes public until the archive is ready.
+printf '%s==> R08 · building %s (before publishing anything)%s\n' "$R_BLUE" "$ZIP_NAME" "$R_NC"
+ZIP="$TMPD/$ZIP_NAME"
+python3 - "$SRC_DIR" "$ZIP" <<'PY'
+import os, subprocess, sys, zipfile
+src, out = sys.argv[1], sys.argv[2]
+# TRACKED files only: what is not in git has been reviewed by nobody and cannot go into a
+# package that installs itself in somebody else's home.
+files = subprocess.run(["git", "ls-files", "-z", "--", src], capture_output=True, check=True
+                       ).stdout.decode().split("\0")
+files = [f for f in files if f and not f.endswith((".pyc", ".pyo"))]
+with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as z:
+    for f in files:
+        z.write(f, os.path.relpath(f, src))   # component contents at the ROOT of the archive
+with zipfile.ZipFile(out) as z:
+    names = z.namelist()
+    assert "manifest.json" in names, "manifest.json is not at the root of the archive"
+    assert z.testzip() is None, "archive is corrupt"
+print(f"    {len(names)} files, archive valid")
+PY
+[ -s "$ZIP" ] || _die "archive not created: publishing nothing."
+
+# ── tag ────────────────────────────────────────────────────────────────────────────
+printf '%s==> tag v%s on %s%s\n' "$R_BLUE" "$NEW" "${SHA:0:8}" "$R_NC"
+# No `-f`: moving an already-published tag is rewriting published history (R09), and the
+# gate could not see it because the forcing was in `git tag`, not in the push.
+if git rev-parse -q --verify "refs/tags/v$NEW" >/dev/null; then
+  [ "$(git rev-list -1 "v$NEW")" = "$SHA" ] || require R09 "tag v$NEW already exists and points at a different commit: moving it would rewrite published history."
+else
+  git tag "v$NEW" "$SHA" || _die "creating the tag failed"
+fi
+push_safe origin "refs/tags/v$NEW" || _die "pushing the tag failed"
+
+# ── GitHub Release ─────────────────────────────────────────────────────────────────
+printf '%s==> GitHub Release (body = the human changelog)%s\n' "$R_BLUE" "$R_NC"
+RESP="$TMPD/rel.json"
+CODE="$(_curl_gh -s -o "$RESP" -w '%{http_code}' -X POST "https://api.github.com/repos/${R_REPO}/releases" \
+  -d "$(python3 -c 'import json,sys;print(json.dumps({"tag_name":"v"+sys.argv[1],"name":"v"+sys.argv[1],"body":open(sys.argv[2],encoding="utf-8").read()}))' "$NEW" "$NOTES")")"
+REL_ID="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get("id") or "")' "$RESP" 2>/dev/null || true)"
+if [ -z "$REL_ID" ]; then
+  REL_ID="$(_gh "releases/tags/v${NEW}" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("id") or "")' 2>/dev/null || true)"
+  [ -n "$REL_ID" ] && echo "    release v$NEW already exists (id $REL_ID): reusing it" || {
+    sed 's/^/  | /' "$RESP" >&2
+    _die "GitHub Release NOT created (HTTP $CODE). ⚠️ Tag v$NEW is already published:
+       fix and run again (the script reuses the tag), or create the release by hand."
+  }
+fi
+
+# ── R08 · upload the asset. The old one is deleted ONLY once the new one is up ─────
+printf '%s==> asset %s%s\n' "$R_BLUE" "$ZIP_NAME" "$R_NC"
+UP="$TMPD/up.json"
+_upload() { # $1 = asset name
+  _curl_gh -s -o "$UP" -w '%{http_code}' -X POST -H "Content-Type: application/zip" \
+    --data-binary @"$ZIP" "https://uploads.github.com/repos/${R_REPO}/releases/${REL_ID}/assets?name=$1"; }
+UPC="$(_upload "$ZIP_NAME")"
+if ! grep -q '"browser_download_url"' "$UP"; then
+  # Retrying after a hiccup: a namesake is already there. ⚠️ It used to delete first and
+  # upload second: if the second attempt failed, a release that had a good zip was left
+  # with none. Now the new one goes up under a temporary name, and only once it is there
+  # is the old one deleted and the new one renamed.
+  UPC="$(_upload "${ZIP_NAME}.new")"
+  NEW_ID="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get("id") or "")' "$UP" 2>/dev/null || true)"
+  if [ -n "$NEW_ID" ]; then
+    OLD="$(_gh "releases/${REL_ID}/assets" | python3 -c "import json,sys;print(next((a['id'] for a in json.load(sys.stdin) if a['name']=='${ZIP_NAME}'),''))" 2>/dev/null || true)"
+    [ -n "$OLD" ] && _curl_gh -s -o /dev/null -X DELETE "https://api.github.com/repos/${R_REPO}/releases/assets/${OLD}"
+    _curl_gh -s -o "$UP" -X PATCH "https://api.github.com/repos/${R_REPO}/releases/assets/${NEW_ID}" \
+      -d "$(python3 -c 'import json,sys;print(json.dumps({"name":sys.argv[1]}))' "$ZIP_NAME")"
+  fi
+fi
+grep -q '"browser_download_url"' "$UP" \
+  && ok "R08 · $ZIP_NAME is on the release" \
+  || { sed 's/^/  | /' "$UP" >&2
+       require R08 "uploading $ZIP_NAME failed (HTTP $UPC): with zip_release set, HACS cannot install this version.
+Upload it by hand onto release v$NEW before telling anybody about it."; }
+
+# ── R18 · the sentence that cannot be skipped ─────────────────────────────────────
+echo
+printf '%s%sPublished v%s.%s  https://github.com/%s/releases/tag/v%s\n\n' "$R_GREEN" "$R_BOLD" "$NEW" "$R_NC" "$R_REPO" "$NEW"
+printf '%s================================================================%s\n' "$R_BOLD" "$R_NC"
+printf '%s NOW IT IS THEIR TURN: HACS -> Omoda 9 / Jaecoo -> Update ->%s\n' "$R_BOLD" "$R_NC"
+printf '%s restart Home Assistant. Say it to them in those words.%s\n' "$R_BOLD" "$R_NC"
+printf '%s================================================================%s\n' "$R_BOLD" "$R_NC"
+echo " After the restart, once HA is RUNNING: the entity count asserted by"
+echo " tests/test_entity_count.py, none of them unavailable (R24)."

--- a/tools/rules.sh
+++ b/tools/rules.sh
@@ -1,0 +1,831 @@
+#!/usr/bin/env bash
+# tools/rules.sh — the rules of this repository, in a form a machine can enforce.
+#
+# This is NOT documentation. It is the library that `pr.sh`, `release.sh` and
+# `check-secrets.sh` load, and every gate in it corresponds to a rule written down in
+# CONTRIBUTING.md, AGENTS.md, docs/field-test.md or SECURITY.md. Where a rule has no
+# prose behind it, it says so: those are house rules of the maintainer who wrote this
+# file, not decisions of the group, and `./tools/rules.sh list` prints them as such.
+#
+# Direct use:
+#   ./tools/rules.sh list       # the rulebook: id, severity, source, whether it has a gate
+#   ./tools/rules.sh check      # preflight: never asks for a derogation, just reports
+#   ./tools/rules.sh log        # every derogation ever granted
+#
+# As a library:  . tools/rules.sh
+#
+# ───────────────────────────── THE RULE ABOUT THE RULES ─────────────────────────────
+# A failing gate STOPS the script. The only way past it is a **derogation**:
+#   * the dialogue happens on /dev/tty, not on stdin/stdout, so `| tee` cannot break it
+#     and a pipe cannot feed it;
+#   * you must type an exact phrase containing a **one-time code printed right then**, so
+#     somebody who cannot see the screen cannot prepare it in advance;
+#   * you must give a reason of at least 20 characters;
+#   * the line goes into DEROGATIONS.log, and **if the log cannot be written the
+#     derogation is not granted**: no derogation without a trace.
+#
+# There is a second door, for agents — see `--authorized` below. It is narrower on
+# purpose: it opens only for NORMAL-severity rules.
+#
+# ⚠️ HONESTY ABOUT THE LIMITS — read this before trusting this file.
+# No local mechanism can tell a person apart from a program that sees the same terminal.
+# `script -qec`, `expect`, `tmux send-keys` and a CI runner with a pty can all read the
+# one-time code and type it back. What this file actually guarantees is:
+#   1. a derogation cannot happen BY ACCIDENT — not from a pipe, not from cron, not from
+#      an agent that has not deliberately built itself a fake terminal;
+#   2. every derogation leaves a written line, or it does not happen.
+# That is a high kerb and an honest register, not a wall. Anyone who writes "unbypassable"
+# is doing the thing this project forbids in writing: claiming a check they do not have.
+set -uo pipefail
+
+# ── where things are ────────────────────────────────────────────────────────────────
+# ⚠️ Do NOT assume this file sits at the top of the working tree. It lives in tools/, so
+# every path is resolved from the repository root, found through git. An earlier version
+# used `dirname "$0"` and, the moment the scripts moved into a subdirectory, looked for
+# custom_components/ inside tools/ and reported that core/ had ceased to exist.
+R_TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+R_ROOT="$(git -C "$R_TOOLS_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$R_ROOT" ]; then
+  echo "tools/rules.sh: not inside a git working tree ($R_TOOLS_DIR). Nothing to check." >&2
+  return 1 2>/dev/null || exit 1
+fi
+DEROGATIONS_LOG="$R_ROOT/DEROGATIONS.log"
+# Extra secret patterns that are specific to one person or one machine (a surname in an
+# e-mail, home paths, the names of private infrastructure). They must NOT be committed —
+# writing them here would publish exactly what they exist to catch — so they live in a
+# gitignored file. See tools/private-patterns.example.txt.
+R_PRIVATE_PATTERNS="$R_TOOLS_DIR/private-patterns.txt"
+
+# The REAL command line of whoever called us. Inside `ask_derogation`, "$*" is the
+# function's own arguments: the register used to say "pr.sh R10", which does not say what
+# was derogated. The caller declares it right after sourcing, with `rules_cmdline "$@"`.
+R_CMDLINE="$(basename "${0}")"
+rules_cmdline() { R_CMDLINE="$(basename "${0}") $*"; }
+
+# Read-only mode: `check` turns it on. A preflight that opens the derogation dialogue is
+# not a preflight — and a subshell does not help: it prevents the exit, not the prompt and
+# not the write to the register.
+R_PREFLIGHT=0
+
+# Set by a caller's `--authorized "<phrase>"`. See `ask_derogation`.
+R_AUTHORIZED="${R_AUTHORIZED:-}"
+
+# Set by gate_suite when no interpreter with pytest could be found, so that pr.sh can
+# say so in the pull request — which is what AGENTS.md asks for.
+R_SUITE_SKIPPED=0
+
+R_RED=$'\e[31m'; R_GREEN=$'\e[32m'; R_YELLOW=$'\e[33m'; R_BLUE=$'\e[36m'; R_NC=$'\e[0m'; R_BOLD=$'\e[1m'
+
+# ══════════════════════════════ THE RULEBOOK ══════════════════════════════
+# id|severity|text|source
+# HIGH   = the damage leaves this room and reaches somebody who is not in it.
+# NORMAL = the damage stays at home (internal quality, wasted work, discipline).
+#
+# A source that begins with "house rule" has NO prose behind it in this repository. It is
+# the practice of the maintainer who wrote these scripts, kept here because the gate is
+# useful — not a decision anybody else has agreed to. Argue with them; they are not
+# smuggled in as project rules.
+R_RULES=(
+"R01|HIGH|Never push to 'master'. Every change lands as a pull request, including from the people who wrote the rules, and including releases.|CONTRIBUTING.md \"Never\" · AGENTS.md \"The commands\" · branch protection, active since 2026-08-22 (#2)"
+"R02|HIGH|Never a secret in the repository: VIN, token, certificate, tUserId, account identifier, e-mail, phone number, raw capture. Not in code, not in tests, not pasted into an issue. The gate is check-secrets.sh, run AFTER the commit and BEFORE the push: against staged-only changes it sees nothing and passes falsely.|CONTRIBUTING.md \"Never\" · AGENTS.md \"Invariants\" · SECURITY.md"
+"R03|HIGH|CI green is a precondition, not a hope: HACS validation, Hassfest and the test suite must be green on the EXACT commit being published.|CONTRIBUTING.md \"It lands\" · branch protection (3 required checks)"
+"R04|HIGH|The changelog is written for people who are not programmers, in the '## [Non rilasciato]' section, in two language blocks with the same content. Never generate_release_notes. This is the text HACS shows to EVERY user at update time.|house rule: the maintainer's release practice. Not in CONTRIBUTING.md or AGENTS.md; AGENTS.md \"Cutting a release\" currently suggests --generate-notes, which contradicts it"
+"R05|HIGH|At most one stable release every 2 weeks: each tag costs every user a HACS notification and a Home Assistant restart. Work accumulates in '[Non rilasciato]'. Exceptions: data loss, account lockout, security.|house rule, from measured history (45 releases in 30 days, 62% of them less than an hour apart). Not in CONTRIBUTING.md or AGENTS.md"
+"R06|NORMAL|Shared code (core/, coordinator.py, authentication, signing, the entity model) asks for a read by somebody who is not the author. The merge is NEVER blocked and required approvals on GitHub are deliberately zero: the block sits on the stable release. Nobody approves because they own the organisation.|CONTRIBUTING.md \"It lands\" (\"Merging is never blocked. Only the last step is.\")"
+"R07|HIGH|Never claim a hardware check you do not have. 'The backend answered OK' is layer 1 and speaks about us; only a state field on the car changing, at a time you can point to, is layer 2 and speaks about the car. Code written for a car nobody owns still merges, labelled unverified-hardware, and a stable release must NAME it rather than folding it in quietly.|CONTRIBUTING.md \"Never\" and \"It becomes stable\" · AGENTS.md \"don't overstate evidence\" · docs/field-test.md"
+"R08|HIGH|A stable release without the omoda9.zip asset is worse than no release: hacs.json sets zip_release, so HACS lists the version and then fails to install it.|AGENTS.md \"Cutting a release\" · hacs.json"
+"R09|HIGH|Never force-push and never rewrite published history. To bring an already-pushed branch up to date use merge, not rebase. On master the protection forbids deletions too.|AGENTS.md \"Never\" and \"When master has moved on\" · branch protection"
+"R10|NORMAL|Never AI co-authorship trailers in commit messages. How this project credits its tools is a decision for the group, not an assistant's default.|AGENTS.md \"Save the work\""
+"R11|NORMAL|No Home Assistant imports inside core/: the protocol logic must stay runnable without HA installed, which is what lets the sandbox exercise a change without an instance.|AGENTS.md \"Invariants\""
+"R12|HIGH|Fail open: if something cannot be read, is unrecognised or times out, send exactly what was sent before (full request, historic endpoint). The worst an untested path may do is fail to help. Never remove or narrow an entity or a command that worked. The entity count is a test.|AGENTS.md \"Invariants\" · tests/test_entity_count.py"
+"R13|NORMAL|One behaviour per pull request. A change nobody can read is not reviewable, and asking for review of an unreadable diff is theatre.|CONTRIBUTING.md \"Keep changes small\""
+"R14|NORMAL|Private material stays out of the repository: credentials, certificates, tokens, raw captures, the legacy bridge, personal handover notes, derogation and comment logs. The tooling itself is NOT private any more: it lives in tools/ and is meant to be read and run by everybody.|CONTRIBUTING.md \"Never\" · SECURITY.md · superseding the maintainer's earlier house rule that kept these scripts out of the repository"
+"R15|HIGH|Never send a command to the car or the backend, not even a read-only one, without an explicit go-ahead from the person whose car it is.|house rule for agent-driven work. Not in AGENTS.md; consistent in spirit with CONTRIBUTING.md \"Never\""
+"R16|NORMAL|Never cut a release in order to test. To test: the suite, your own instance, or the 'beta' label on the pull request, which builds a pre-release installable from HACS.|AGENTS.md \"Get it onto a real car\" · CONTRIBUTING.md \"It ships\" · .github/workflows/beta.yml (#12)"
+"R17|NORMAL|The single source of truth is this repository. Never edit the installed copy under the Home Assistant config directory: that fix dies at the next HACS update and nobody ever sees it again.|house rule, but it generalises to anyone developing an HA integration. Not in CONTRIBUTING.md or AGENTS.md"
+"R18|NORMAL|After publishing, say explicitly to the car owner that the next step is theirs: HACS - update - restart Home Assistant.|house rule about how an agent hands back to the person it works for. Not in CONTRIBUTING.md or AGENTS.md"
+"R19|HIGH|Before a STABLE release, every model in the blast radius must have a field test: a report from somebody who owns that car, in the form of docs/field-test.md. It is the only gate the sources call real.|CONTRIBUTING.md \"It becomes stable\" (\"This is the only real gate\")"
+"R20|NORMAL|A read is promised within one week. If nobody reads it, the author merges it themselves and labels it merged-unread: the rule must fail loudly instead of stopping everyone.|CONTRIBUTING.md \"The one-week rule\""
+"R21|HIGH|No model names as code paths: a new car is data plus capabilities discovered at runtime, not an if model == ... If you need one, you have found an architecture problem: say so instead of encoding it.|AGENTS.md \"Invariants\""
+"R22|HIGH|A GitHub token must never be committed nor left in .git/config. Pushing uses an authentication that is not written to disk.|derived from AGENTS.md \"Invariants\" (no secrets) and \"I committed something secret\" · SECURITY.md"
+"R23|HIGH|The version in manifest.json must already match the tag being published: HACS installs that package under that number.|AGENTS.md \"Cutting a release\""
+"R24|NORMAL|After an update, check on the running instance: Home Assistant RUNNING, the entity count that tests/test_entity_count.py asserts, none of them unavailable. Count only once HA is RUNNING: during start-up you see none, and that is not a fault.|tests/test_entity_count.py for the number; the post-update inspection itself is a house rule"
+"R25|HIGH|Who did the work: a person or an agent. Every claim of work done (I read, I checked, I counted, I tested) must say whether a person did it or an agent under their guidance. 'I read it' and 'the agent I drive read it' are not the same claim, and letting them blur makes a sentence weigh more than it earned. Applies to commit messages, pull request bodies, release notes and issue comments.|CONTRIBUTING.md \"Never\" (\"Say you read something when your agent read it\", merged in #28) · AGENTS.md \"don't overstate evidence\" · convention adopted by @drake69 in #7"
+"R26|HIGH|Before publishing a reply, re-read the thread: if somebody wrote AFTER the draft was saved, stop. The comparison is mechanical - the draft's last-modified time against the comments' timestamps - because time always passes between writing and publishing, and the more careful the message the more time that is.|from a real mistake on 2026-08-24: a request for a review published 38 minutes after that review had already been given. Enforced only in the maintainer's local drafting tool, which is not part of this repository"
+)
+
+rule_row()      { local id="$1" r; for r in "${R_RULES[@]}"; do [ "${r%%|*}" = "$id" ] && { echo "$r"; return 0; }; done; return 1; }
+rule_text()     { rule_row "$1" | cut -d'|' -f3; }
+rule_source()   { rule_row "$1" | cut -d'|' -f4; }
+rule_severity() { rule_row "$1" | cut -d'|' -f2; }
+
+# ══════════════════════════════ THE GATE ══════════════════════════════
+
+_die() { printf '%s%sSTOP.%s %s\n' "$R_RED" "$R_BOLD" "$R_NC" "$*" >&2; exit 1; }
+
+# Trying to get past the gate through the environment is itself a reason to stop.
+# ⚠️ R_PY and R_PREFLIGHT are on this list because they WERE the shortcut: the first chose
+# the interpreter for the suite (R_PY=/bin/true meant R12 green without running a test),
+# the second turns derogations off. Found by an adversarial review on 2026-08-24.
+_no_shortcuts() {
+  local v
+  # Only variables this file does not set itself: a "already checked" memo would itself be
+  # settable from the environment, i.e. the shortcut for skipping the shortcut check.
+  for v in OMODA9_DEROGA OMODA9_FORCE OMODA9_SKIP_GATE SKIP_CHECKS R_PY R_PYTEST; do
+    if [ -n "${!v:-}" ]; then
+      _die "environment variable $v is set: that is a shortcut, not a derogation.
+       Derogations are typed by hand at a terminal, or authorised with --authorized.
+       Unset it and run again."
+    fi
+  done
+}
+
+# ask_derogation <ID> — returns 0 if granted; otherwise exits.
+ask_derogation() {
+  local id="$1" severity text source phrase reason expected nonce
+  severity="$(rule_severity "$id")"; text="$(rule_text "$id")"; source="$(rule_source "$id")"
+
+  { echo
+    printf '%s%s== RULE %s - NOT SATISFIED ============================%s\n' "$R_RED" "$R_BOLD" "$id" "$R_NC"
+    printf '%s|%s %s\n' "$R_RED" "$R_NC" "$text"
+    printf '%s|%s %ssource:%s %s\n' "$R_RED" "$R_NC" "$R_BLUE" "$R_NC" "$source"
+    printf '%s============================================================%s\n' "$R_RED" "$R_NC"
+  } >&2
+
+  # In preflight nobody is asked anything: report and leave.
+  [ "${R_PREFLIGHT:-0}" = "1" ] && _die "(preflight: rule $id is not satisfied)"
+
+  # ── the narrow door, for agents ───────────────────────────────────────────────────
+  # An agent has no /dev/tty, so without this every failing gate is a wall with no
+  # recourse — and a tool that can only be used when everything is already green is a
+  # tool nobody uses. What --authorized carries is the sentence the person said in the
+  # conversation. This script CANNOT verify it: whoever runs the script types it. What is
+  # still true: it opens only for NORMAL rules, and it is written down verbatim.
+  if [ -n "${R_AUTHORIZED:-}" ]; then
+    if [ "$severity" = "HIGH" ]; then
+      _die "rule $id is HIGH severity: --authorized does not open it.
+       The damage it prevents does not stay at home. This one needs a person at a terminal."
+    fi
+    [ "${#R_AUTHORIZED}" -ge 10 ] || _die "the authorisation phrase is too short to mean anything."
+    printf '%s\t%s\t%s\t%s\t%s\n' \
+      "$(_now)" "$(id -un)" "$id" "$R_CMDLINE" "AUTHORIZED: $R_AUTHORIZED" \
+      >> "$DEROGATIONS_LOG" \
+      || _die "cannot write $DEROGATIONS_LOG: no derogation without a trace."
+    { printf '%sRule %s waived on this authorisation:%s "%s"\n' "$R_YELLOW" "$id" "$R_NC" "$R_AUTHORIZED"
+      printf '%s(the script cannot verify it — it is recorded word for word in %s)%s\n' \
+        "$R_YELLOW" "$(basename "$DEROGATIONS_LOG")" "$R_NC"; } >&2
+    return 0
+  fi
+
+  # The dialogue lives on /dev/tty, not on stdin/stdout, so `| tee log` cannot break it and
+  # a pipe cannot feed it. If /dev/tty is not there, there is nobody to ask.
+  # ⚠️ `[ -r /dev/tty ]` is not enough: the node exists and is readable by permission even
+  # when the process has no controlling terminal, and the open then fails with ENXIO,
+  # printing a bash error and carrying on with an empty answer. So we try to OPEN it.
+  if ! { exec 3<>/dev/tty; } 2>/dev/null; then
+    { echo; echo "No terminal (/dev/tty unavailable): there is nobody here who could derogate."
+      echo "That covers agents, cron, pipes and non-interactive sessions, on purpose."
+      echo "For a NORMAL-severity rule, re-run with: --authorized \"<what you were told>\""; } >&2
+    _die "rule $id cannot be derogated in this context. It needs a person at a terminal."
+  fi
+
+  # One-time code: somebody who cannot see the screen cannot prepare the phrase in advance.
+  nonce="$(tr -dc 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789' </dev/urandom | head -c4)"
+  if [ "$severity" = "HIGH" ]; then
+    { echo
+      printf '%sThis rule is HIGH severity: the damage it prevents does NOT stay at home.\n' "$R_YELLOW"
+      printf 'It reaches somebody who is not in this room - a HACS user, the owner of a car\n'
+      printf 'that is not yours, anybody reading the public repository. What lands on GitHub\n'
+      printf 'must be treated as public forever.%s\n' "$R_NC"; } >&3
+    expected="I WAIVE $id $nonce AND I TAKE RESPONSIBILITY"
+  else
+    expected="I WAIVE $id $nonce"
+  fi
+
+  { echo
+    echo "To waive it, type this phrase EXACTLY (or press Enter to stop):"
+    printf '    %s%s%s\n' "$R_BOLD" "$expected" "$R_NC"
+    printf '> '; } >&3
+  IFS= read -r phrase <&3 || phrase=""
+  [ "$phrase" = "$expected" ] || _die "phrase did not match: no derogation. Rule $id stands."
+
+  { echo "Reason (at least 20 characters, it stays in the register):"; printf '> '; } >&3
+  IFS= read -r reason <&3 || reason=""
+  [ "${#reason}" -ge 20 ] || _die "reason too short: no derogation. A derogation without a written reason is not a decision, it is an oversight."
+
+  # ⚠️ No derogation without a trace: if the register cannot be written, it does not count.
+  printf '%s\t%s\t%s\t%s\t%s\n' \
+    "$(_now)" "$(id -un)" "$id" "$R_CMDLINE" "$reason" >> "$DEROGATIONS_LOG" \
+    || _die "cannot write $DEROGATIONS_LOG: no derogation without a trace."
+  printf '%sDerogation %s granted and recorded in %s.%s\n\n' \
+    "$R_YELLOW" "$id" "$(basename "$DEROGATIONS_LOG")" "$R_NC" >&2
+  exec 3>&-
+  return 0
+}
+
+# `date -Is` is GNU-only; this form works on BSD/macOS too.
+_now() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+require() {
+  local id="$1"; shift
+  printf '%sx%s %s\n' "$R_RED" "$R_NC" "$*" | sed '2,$s/^/      /' >&2
+  ask_derogation "$id"
+}
+ok()   { printf '%s+%s %s\n' "$R_GREEN" "$R_NC" "$*"; }
+warn() { printf '%s!%s %s\n' "$R_YELLOW" "$R_NC" "$*"; }
+
+# ══════════════════════════ BASIC TOOLS ══════════════════════════
+
+# What the gates take for granted. `zip(1)` is NOT installed everywhere: found by an
+# adversarial review that simulated `publish` to the end and got a tag and a release
+# published with ZERO assets — exactly what R08 calls "worse than no release". The archive
+# is therefore built with python, which the scripts already require.
+gate_tools() {
+  local c missing=""
+  for c in git curl python3; do command -v "$c" >/dev/null || missing="$missing $c"; done
+  [ -n "$missing" ] && _die "missing indispensable tools:$missing"
+  ok "tools present (the archive is built with python, not with zip(1))"
+}
+
+# ── the token must never touch the disk or the command line (R22) ───────────────────
+# curl: the token is passed as a config file on stdin, not with `-H` on the command line,
+# which /proc/<pid>/cmdline exposes to anyone on the machine.
+_curl_gh() { # $@ = curl arguments, without authentication
+  # ⚠️ `set -u` inside a command substitution kills the SUBSHELL, not the script: an unset
+  # R_TOKEN became an empty response, and the R03 gate then diagnosed "CI never ran"
+  # instead of "I have no token". Better to die saying the truth.
+  : "${R_TOKEN:?a GitHub token is needed (GH_TOKEN, GITHUB_TOKEN, or \`gh auth login\`)}"
+  : "${R_REPO:?the repository name is needed}"
+  printf 'header = "Authorization: token %s"\nheader = "Accept: application/vnd.github+json"\n' "$R_TOKEN" \
+    | curl --config - "$@"
+}
+_gh() { _curl_gh -sfL "https://api.github.com/repos/${R_REPO}/$1" 2>/dev/null; }
+
+# Where a token comes from, in order. `gh auth token` is listed because AGENTS.md tells
+# contributors to run `gh auth login`, and a tool that then demands a second, hand-made PAT
+# is a tool people work around.
+rules_token() {
+  local t="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+  [ -n "$t" ] || t="$(gh auth token 2>/dev/null || true)"
+  printf '%s' "$t"
+}
+
+# git: authentication goes in a header, NEVER in a URL — a URL with the token in it lands
+# in .git/config on the first `push -u` and stays there (R22).
+_git_push() { # $@ = git push arguments (no -u, no URL)
+  local auth
+  # `base64 -w0` is GNU-only and fails on macOS; `base64 | tr -d '\n'` works on both.
+  auth="$(printf 'x-access-token:%s' "$R_TOKEN" | base64 | tr -d '\n')"
+  git -C "$R_ROOT" -c "http.extraHeader=Authorization: Basic $auth" push "$@"
+}
+
+# ══════════════════════════════ THE GATES ══════════════════════════════
+
+# ── R01 / R09 — the only place anything is pushed from ──────────────────────────────
+# ⚠️ There used to be two gates that inspected strings DIFFERENT from the ones handed to
+# git: `gate_never_push_master "$BR"` got the short name while git got
+# `HEAD:refs/heads/<br>`, and the force check ran AFTER a `git tag -f`. Now there is one
+# door and it receives the real arguments.
+push_safe() { # $@ = exactly what you want to hand to git push
+  local a ref
+  for a in "$@"; do
+    case "$a" in
+      -f|--force|--force-*|--mirror|--delete|--prune|+*)
+        require R09 "argument '$a': this is how somebody else's history gets lost." ;;
+    esac
+    # every refspec: look at the DESTINATION, after the colon, normalised.
+    case "$a" in -*) continue;; esac
+    ref="${a##*:}"; ref="${ref#refs/heads/}"; ref="${ref#refs/tags/}"
+    case "$(printf '%s' "$ref" | tr 'A-Z' 'a-z')" in
+      master|main) require R01 "this would push to '$ref'. master is reached only through a pull request." ;;
+    esac
+  done
+  ok "R01/R09 · push allowed: $*"
+  _git_push "$@"
+}
+
+gate_not_on_master() {
+  local br; br="$(git -C "$R_ROOT" rev-parse --abbrev-ref HEAD)"
+  case "$(printf '%s' "$br" | tr 'A-Z' 'a-z')" in
+    master|main) require R01 "you are on branch '$br': nothing is committed or pushed from here." ;;
+    *) ok "R01 · working branch: $br" ;;
+  esac
+}
+
+# ── R02 / R22 — secrets ─────────────────────────────────────────────────────────────
+gate_secrets() {
+  printf '%s==> R02 · secret gate (check-secrets.sh over the whole history)%s\n' "$R_BLUE" "$R_NC"
+  if [ ! -x "$R_TOOLS_DIR/check-secrets.sh" ]; then
+    require R02 "tools/check-secrets.sh is missing or not executable: the gate cannot even run."
+  else
+    local out rc
+    out="$("$R_TOOLS_DIR/check-secrets.sh" 2>&1)"; rc=$?
+    if [ "$rc" -ne 0 ] || ! grep -q 'RESULT: PASS' <<<"$out"; then
+      tail -40 <<<"$out" >&2
+      require R02 "check-secrets.sh did not pass (exit $rc)."
+    else
+      grep -q 'PASS with warnings' <<<"$out" && warn "R02 · PASS with warnings: re-read the '!' lines from check-secrets.sh"
+      ok "R02 · no secret in HEAD or in the history"
+    fi
+  fi
+  gate_token_not_in_git_config
+}
+
+# check-secrets.sh scans the history and the working tree: .git/config is neither, so it
+# was a structural blind spot — and it is exactly where the PAT landed on the first
+# `push -u`.
+gate_token_not_in_git_config() {
+  local dirty
+  dirty="$(git -C "$R_ROOT" config --local --list 2>/dev/null \
+           | grep -iE '(https?://[^:@[:space:]]+:[^@[:space:]]+@)|gh[pousr]_[A-Za-z0-9]{20,}' || true)"
+  if [ -n "$dirty" ]; then
+    require R22 "there is a credential in cleartext in .git/config:$(printf '\n%s' "$(sed 's/:[^:@]*@/:***@/' <<<"$dirty")")
+Remove it with: git config --local --unset <key>"
+  else
+    ok "R22 · no credential in .git/config"
+  fi
+}
+
+# ── R03 — CI green on the exact commit ──────────────────────────────────────────────
+gate_ci_green() { # $1 = sha
+  local sha="${1:?}" json verdict
+  printf '%s==> R03 · CI on commit %s%s\n' "$R_BLUE" "${sha:0:8}" "$R_NC"
+  if ! json="$(_gh "commits/$sha/check-runs?per_page=100")"; then
+    require R03 "could not ask GitHub for the CI status (network, token or permissions).
+The gate fails closed: without an answer, nothing is published."
+    return 0
+  fi
+  verdict="$(python3 - "$json" <<'PY'
+import json, sys
+try:
+    d = json.loads(sys.argv[1] or "")
+except Exception:
+    print("NOJSON"); raise SystemExit
+runs = d.get("check_runs") or []
+expected = {"HACS validation", "Hassfest", "Suite di test"}
+seen = {}
+for r in runs:
+    n = r["name"]
+    if n not in seen or (r.get("started_at") or "") > (seen[n].get("started_at") or ""):
+        seen[n] = r
+missing = expected - set(seen)
+if missing:
+    print("MISSING:" + ",".join(sorted(missing))); raise SystemExit
+bad = [n for n in expected if seen[n].get("status") != "completed"
+       or seen[n].get("conclusion") != "success"]
+print("RED:" + ",".join(sorted(bad)) if bad else "GREEN")
+PY
+)"
+  case "$verdict" in
+    GREEN)     ok "R03 · the three required checks are green on ${sha:0:8}" ;;
+    NOJSON)    require R03 "could not read the CI status from GitHub (the gate fails closed)." ;;
+    MISSING:*) require R03 "checks absent on ${sha:0:8}: ${verdict#MISSING:} (did CI ever run on this commit?)" ;;
+    RED:*)     require R03 "checks NOT green on ${sha:0:8}: ${verdict#RED:}" ;;
+    *)         require R03 "CI verdict could not be interpreted: $verdict" ;;
+  esac
+}
+
+# ── R04 — changelog, human and in both languages ────────────────────────────────────
+gate_changelog() { # $1 = LITERAL heading to inspect (e.g. "## v1.13.1")
+  local heading="${1:-## [Non rilasciato]}" f="$R_ROOT/CHANGELOG.md" body it en
+  printf '%s==> R04 · changelog%s\n' "$R_BLUE" "$R_NC"
+  body="$(awk -v v="$heading" 'index($0,v)==1 {f=1;next} /^## /{f=0} f' "$f")"
+  if ! grep -qE '[[:alnum:]]' <<<"$body"; then
+    require R04 "section '$heading' of the CHANGELOG is empty: there is nothing to show the user in HACS."
+    return 0
+  fi
+  it="$(awk '/^### .*Italiano/{f=1;next} /^###? /{f=0} f' <<<"$body" | grep -cE '^[-*]' || true)"
+  en="$(awk '/^### .*English/{f=1;next}  /^###? /{f=0} f' <<<"$body" | grep -cE '^[-*]' || true)"
+  if [ "${it:-0}" -eq 0 ] || [ "${en:-0}" -eq 0 ]; then
+    require R04 "changelog is not bilingual: Italian entries=${it:-0}, English=${en:-0}. HACS shows one single text to everybody, so both must be there."
+  elif [ "$it" -ne "$en" ]; then
+    warn "R04 · IT=$it EN=$en entries: the two sections should say the same thing, check."
+  else
+    ok "R04 · bilingual changelog, $it entries per language"
+  fi
+}
+
+# ── which tags count as a RELEASE ───────────────────────────────────────────────────
+# .github/workflows/beta.yml (#12) cuts pre-releases from a pull request labelled 'beta',
+# tagged vX.Y.Z-beta.N. Those are not releases: they are the pull request made installable.
+# Counting them as releases does two things, both silent:
+#   * R05 would see "0 days since the last release" the day after every beta and block
+#     every stable for two weeks — a gate that always fires is the surest way to teach
+#     people to derogate;
+#   * the evidence inventory in release.sh (R07/R19) would start from the beta instead of
+#     the last stable: pull requests merged before it would fall outside the release body,
+#     and with an empty inventory R19 — the only gate the sources call real — would not
+#     fire at all.
+# Right-anchored: `v1.13.0` matches, `v1.13.0-beta.3` does not.
+R_TAG_RELEASE='^v[0-9]+\.[0-9]+\.[0-9]+([[:space:]]|$)'
+
+# ── R05 — cadence ───────────────────────────────────────────────────────────────────
+gate_cadence() { # $1 = (optional) the version being published, NOT to be counted
+  local exclude="${1:-}" last days
+  printf '%s==> R05 · distance from the last release%s\n' "$R_BLUE" "$R_NC"
+  # ⚠️ Excluding the in-flight tag is not a detail: a half-failed attempt leaves the local
+  # tag behind, and on the retry the cadence gate blocked the recovery of your OWN broken
+  # release. Found in adversarial review on 2026-08-24.
+  last="$(git -C "$R_ROOT" for-each-ref --sort=-creatordate \
+            --format='%(refname:short) %(creatordate:unix)' refs/tags \
+          | grep -E "$R_TAG_RELEASE" \
+          | grep -v "^v${exclude} " | head -1 | awk '{print $2}')"
+  if [ -z "$last" ]; then ok "R05 · no previous tag"; return 0; fi
+  days=$(( ( $(date +%s) - last ) / 86400 ))
+  if [ "$days" -lt 14 ]; then
+    require R05 "$days days since the last release (minimum 14). If this is data loss, account lockout or security, derogate and write that in the reason."
+  else
+    ok "R05 · $days days since the last release"
+  fi
+}
+
+# ── R06 — a read by somebody else: reported, not blocked (the source says so) ────────
+R_SHARED_RE='^custom_components/omoda9/(core/|coordinator\.py|config_flow\.py|__init__\.py|const\.py|entity\.py)'
+gate_shared_code() { # $1 = base
+  local base="${1:-origin/master}" touched
+  touched="$(git -C "$R_ROOT" diff --name-only "$base"...HEAD | grep -E "$R_SHARED_RE" || true)"
+  if [ -n "$touched" ]; then
+    warn "R06 · touches shared code:"
+    sed 's/^/      /' <<<"$touched"
+    echo "      -> ask for a read from somebody who is not the author. The merge is not blocked:"
+    echo "         if nobody reads it within a week, merge and label it 'merged-unread' (R20)."
+    R_NEEDS_READ=1
+  else
+    ok "R06 · no shared file touched"
+    R_NEEDS_READ=0
+  fi
+}
+
+# ── R07 — the evidence declaration ──────────────────────────────────────────────────
+# R_EVIDENCE_KIND lets a caller (an agent, with no terminal) state the evidence instead of
+# falling back to the safest claim. ⚠️ It deliberately CANNOT say "verified on hardware":
+# that answer means somebody watched a car, and nothing running without a person present is
+# in a position to say so. The other three answers only ever weaken a claim, so letting a
+# script make them costs nothing — while defaulting a documentation change to
+# `unverified-hardware` puts a false line in the next release notes, which is the failure
+# this rule exists to prevent.
+R_EVIDENCE_KIND="${R_EVIDENCE_KIND:-}"
+gate_field_test() {
+  local r d
+  case "$R_EVIDENCE_KIND" in
+    backend)  R_EVIDENCE="**Backend only** - the request was accepted; nobody watched the car act."
+              R_LABELS="unverified-hardware"
+              ok "R07 · declared: backend only"; return 0 ;;
+    not-mine) R_EVIDENCE="**Not testable by me** - written for a model the author does not own."
+              R_LABELS="unverified-hardware"
+              ok "R07 · declared: model not owned"; return 0 ;;
+    none)     R_EVIDENCE="**No runtime behaviour** - docs, tests, CI: nothing a user can see changes."
+              R_LABELS=""
+              ok "R07 · declared: no runtime behaviour"; return 0 ;;
+    hardware) _die "R07: 'verified on hardware' cannot be declared from a flag. It means somebody
+       watched the car do it, so it is answered at a terminal, by that person." ;;
+    ?*)       _die "R07: unknown evidence '$R_EVIDENCE_KIND' (use: backend | not-mine | none)." ;;
+  esac
+  if ! { exec 3<>/dev/tty; } 2>/dev/null; then
+    R_EVIDENCE="Not declared: pull request opened without a terminal."
+    R_LABELS="unverified-hardware"
+    warn "R07 · no terminal and no --evidence: the PR is born labelled unverified-hardware,"
+    echo "      the only safe claim. If nothing a user can see changes, say so: --evidence none"
+    return 0
+  fi
+  { echo
+    printf '%sR07 - the only question that matters (docs/field-test.md):%s\n' "$R_BOLD" "$R_NC"
+    echo "  1) I watched the CAR do it: I know which state field changed, and when."
+    echo "  2) I only saw the BACKEND answer OK."
+    echo "  3) I do not own that model: I could not test it."
+    echo "  4) No runtime behaviour (docs, tests, CI)."
+    printf '> [1/2/3/4] '; } >&3
+  IFS= read -r r <&3 || r=3
+  case "$r" in
+    1) printf "   Which field changed, and at what time? > " >&3; IFS= read -r d <&3
+       R_EVIDENCE="**Verified on hardware** - observed on the car: $d"; R_LABELS="" ;;
+    2) R_EVIDENCE="**Backend only** - the request was accepted; nobody watched the car act."
+       R_LABELS="unverified-hardware" ;;
+    4) R_EVIDENCE="**No runtime behaviour** - docs, tests, CI: nothing a user can see changes."
+       R_LABELS="" ;;
+    *) R_EVIDENCE="**Not testable by me** - written for a model the author does not own."
+       R_LABELS="unverified-hardware" ;;
+  esac
+  exec 3>&-
+  ok "R07 · declaration recorded"
+}
+
+# ── R10 — no AI trailers ────────────────────────────────────────────────────────────
+# ⚠️ The previous regex looked for the substring 'AI' and blocked "...@gmail.com" and
+# "@hotmail.it" (a human co-author could no longer land anything), while letting Gemini,
+# Cursor and "Assisted-by:" through. Now the subjects are listed.
+_TRAILER_RE='(^|[[:space:]])(co-authored-by|assisted-by|generated-by):[[:space:]]*[^[:space:]]*(claude|anthropic|openai|gpt|copilot|gemini|cursor|codex|devin|aider|llm)|generated with[[:space:]]*\[?(claude|gpt|copilot)'
+gate_no_trailer() { # $1 = the TEXT of the message (never a filename)
+  if grep -qEi "$_TRAILER_RE" <<<"${1:-}"; then
+    require R10 "the commit message carries an AI co-authorship trailer."
+  else
+    ok "R10 · no AI trailer in the message"
+  fi
+}
+gate_no_trailer_in_commits() { # $1 = base
+  local dirty
+  dirty="$(git -C "$R_ROOT" log --format='%H %s%n%b' "${1:-origin/master}"..HEAD | grep -Ei "$_TRAILER_RE" || true)"
+  [ -n "$dirty" ] && require R10 "AI trailer in a commit that is already made:$(printf '\n%s' "$dirty")" \
+                  || ok "R10 · no AI trailer in this branch's commits"
+}
+
+# ── R11 / R21 — architecture invariants ─────────────────────────────────────────────
+gate_core_without_ha() {
+  local core="$R_ROOT/custom_components/omoda9/core" h
+  # ⚠️ Without this line the gate went green when core/ no longer existed: grep failed,
+  # `|| true` zeroed it, and absence looked like compliance.
+  [ -d "$core" ] || { require R11 "custom_components/omoda9/core/ does not exist: the gate does not know what to look at."; return 0; }
+  h="$(grep -rnE '^[[:space:]]*(from|import)[[:space:]]+homeassistant|import_module\(["'"'"']homeassistant|__import__\(["'"'"']homeassistant' "$core" 2>/dev/null || true)"
+  [ -n "$h" ] && require R11 "Home Assistant imported inside core/:$(printf '\n%s' "$h")" \
+              || ok "R11 · core/ does not import Home Assistant"
+}
+gate_no_model_names() {
+  local cc="$R_ROOT/custom_components/omoda9" h
+  [ -d "$cc" ] || return 0
+  h="$(grep -rnEi 'if[^:]*\b(model|modello|marca|brand)\b[^:]*==[[:space:]]*["'"'"'](omoda|jaecoo|j7|e5|c5)' "$cc" 2>/dev/null || true)"
+  [ -n "$h" ] && require R21 "a model name used as a code path:$(printf '\n%s' "$h")" \
+              || ok "R21 · no model name used as a code path"
+}
+
+# ── R12 — the suite, and with it the entity count ───────────────────────────────────
+# ⚠️ The interpreter is NOT taken from the environment: `R_PY=/bin/true` made this gate
+# pass without running a single test, and it was the variable the rulebook swore did not
+# exist. Known locations are searched instead — none of them absolute, so this works on
+# somebody else's machine.
+_find_python() {
+  local p
+  for p in "${VIRTUAL_ENV:-}/bin/python" \
+           "$R_ROOT/.venv/bin/python" "$R_ROOT/.venv-test/bin/python" \
+           "$R_ROOT/venv/bin/python" "$R_ROOT/env/bin/python" \
+           python3.14 python3.13 python3; do
+    [ "$p" = "/bin/python" ] && continue
+    command -v "$p" >/dev/null 2>&1 || [ -x "$p" ] || continue
+    "$p" -c 'import pytest' >/dev/null 2>&1 && { printf '%s' "$p"; return 0; }
+  done
+  return 1
+}
+gate_suite() {
+  printf '%s==> R12 · test suite%s\n' "$R_BLUE" "$R_NC"
+  local py out rc
+  if ! py="$(_find_python)"; then
+    # ⚠️ This case is a WARNING, not a stop, and the source is explicit about it:
+    # AGENTS.md, "Run the checks locally if you can" — "If the local Python is older, skip
+    # it and let CI be the gate - that is why CI exists - but say so in the pull request."
+    # pr.sh reads R_SUITE_SKIPPED and says so in the body. A red suite still stops.
+    R_SUITE_SKIPPED=1
+    warn "R12 · no interpreter with pytest here (tried \$VIRTUAL_ENV, .venv, .venv-test, venv, env, python3.14/3.13/3)."
+    echo "      Home Assistant needs Python 3.13+. CI is the gate; the pull request will say the"
+    echo "      suite did not run locally, which is what AGENTS.md asks for."
+    return 0
+  fi
+  out="$(cd "$R_ROOT" && "$py" -m pytest tests/ -q 2>&1)"; rc=$?
+  if [ "$rc" -ne 0 ]; then
+    tail -25 <<<"$out" >&2
+    require R12 "the suite is not green. 'Green in a follow-up' does not count: green in the pull request that changes the behaviour."
+  else
+    ok "R12 · $(grep -oE '[0-9]+ passed' <<<"$out" | tail -1) ($py)"
+  fi
+}
+
+# ── R14 — private material stays out of the repository ──────────────────────────────
+# ⚠️ Two families, anchored differently, and the difference is NOT pedantry: half of the
+# private filenames collide with real modules of the component (core/commands.py,
+# core/session.py, core/wake.py). Anchored everywhere, the gate declared "private material
+# in the repository" on eleven legitimate files and blocked every pull request.
+#   - family 1: unambiguous names -> anywhere in the tree;
+#   - family 2: names that collide with the component -> ONLY at the root, which is where
+#     the untracked private material lives.
+# Note what is NOT here any more: rules.sh, pr.sh, release.sh, check-secrets.sh. They used
+# to be private and are now part of the repository, in tools/. The root-anchored entries
+# still catch the maintainer's stale copies at the top of the working tree.
+_PRIVATE_RE='(^|/)(omoda9\.env|\.mqtt_cred|token\.json)|(^|/)certs_eu/|(^|/)(DEROGATIONS|DEROGHE|COMMENTI)\.log$|(^|/)private-patterns\.txt$|(^|/)ha_bridge\.py$|\.bak_|(^|/)(HANDOFF_[^/]*|AUDIT_REPORT|PATCH_1\.0|ENTITA_HA|SHARING_TODO|REGOLE)\.md$|^(regole|deploy|check_secrets)\.sh$|^(rules|pr|release)\.sh$|^hacs_refresh\.py$|^(commands|login_omoda|omoda|omoda_auth|probe|prova_token|provision|session|tsp_sign|wake|captcha_solver)\.py$'
+gate_private_material_out() {
+  local inside
+  # -z + core.quotePath=false: without them, a file called "odd release.sh" is quoted by
+  # git and the pattern anchor no longer matches.
+  inside="$(git -C "$R_ROOT" -c core.quotePath=false ls-files -z | tr '\0' '\n' | grep -Ei "$_PRIVATE_RE" || true)"
+  [ -n "$inside" ] && require R14 "private material tracked in the repository:$(printf '\n%s' "$inside")" \
+                   || ok "R14 · no private material is tracked"
+}
+# ── R14, the other direction: the tooling must be VISIBLE to git ────────────────────
+# ⚠️ This gate exists because of a real, silent failure while these scripts were being
+# moved into tools/. The maintainer's .git/info/exclude carried bare entries — `pr.sh`,
+# `release.sh` — from the years when they were private. A gitignore pattern **without a
+# slash matches at any depth**, so `tools/pr.sh` and `tools/release.sh` were ignored, and
+# every `git add -A` dropped them without a word. The commit looked fine and two of the
+# five files simply were not in it. Anybody who copies an old exclude file inherits the
+# same trap, which is why it is checked rather than remembered.
+gate_tools_visible() {
+  local ignored
+  ignored="$(cd "$R_ROOT" && git check-ignore tools/* 2>/dev/null || true)"
+  if [ -n "$ignored" ]; then
+    require R14 "git is IGNORING part of the tooling, so it would silently never be committed:$(printf '\n%s' "$ignored")
+Almost certainly a leftover entry in .gitignore or .git/info/exclude written without a
+leading slash (\`pr.sh\` instead of \`/pr.sh\`), which matches at any depth."
+  else
+    ok "R14 · git can see the whole of tools/"
+  fi
+}
+
+# Call this BEFORE every `git add`: what is about to go in, not what is already in.
+# ⚠️ `--untracked-files=all` and `-z` are not refinements: with the normal listing a new
+# directory appears as 'stuff/' (and the files inside escape) and a name with a space is
+# quoted and split — 'omoda9.env backup' went through untouched.
+gate_stage_clean() {
+  local new f
+  new=""
+  while IFS= read -r -d '' line; do
+    f="${line:3}"
+    grep -qEi "$_PRIVATE_RE" <<<"$f" && new="$new$f"$'\n'
+  done < <(git -C "$R_ROOT" -c core.quotePath=false status --porcelain -z --untracked-files=all)
+  if [ -n "$new" ]; then
+    printf '%s      (add them to .gitignore, or remove the files)%s\n' "$R_YELLOW" "$R_NC" >&2
+    require R14 "a 'git add -A' would take private material into the repository:$(printf '\n%s' "$new")"
+  else
+    ok "R14 · no private material would end up in the commit"
+  fi
+}
+
+# ── R23 — manifest and tag ──────────────────────────────────────────────────────────
+# `grep -oP` is GNU-only (and a JSON file deserves a JSON parser).
+manifest_version() {
+  python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["version"])' \
+    "$R_ROOT/custom_components/omoda9/manifest.json"
+}
+gate_manifest_matches_tag() { # $1 = X.Y.Z
+  local v; v="$(manifest_version)"
+  [ "$v" = "$1" ] && ok "R23 · manifest $v = tag v$1" \
+                  || require R23 "the manifest says $v but the tag would be v$1: HACS would install a package that does not match the version."
+}
+
+# ── R25 — who did the work: a person or an agent ────────────────────────────────────
+# ⚠️ This gate CANNOT verify an attribution: no program knows who actually read a file. It
+# can do one thing, and it is the thing that helps: stop a sentence going out WITHOUT
+# saying. It asks, records, and moves on. Calling it "verification" would be the very
+# thing this rule forbids.
+# Stated limit: it recognises explicit first person ("I checked", "ho verificato"), NOT
+# impersonal forms ("Verified: 107 entities"), which are ambiguous by construction and
+# would produce so many false positives that they would only teach people to ignore it.
+_CLAIM_RE=$'\\b(i|we)( have|\'ve)? +(read|verified|checked|tested|measured|counted|ran|run|reviewed|confirmed|inspected|reproduced|observed|audited|traced|diffed|found|wrote|written)\\b|\\b(ho|abbiamo) +(letto|riletto|verificat[oi]|controllat[oi]|provat[oi]|testat[oi]|misurat[oi]|contat[oi]|guardat[oi]|eseguit[oi]|lanciat[oi]|confrontat[oi]|revisionat[oi]|ispezionat[oi]|analizzat[oi]|riprodott[oi]|osservat[oi]|collaudat[oi]|visto|scritto|trovato|scoperto)\\b'
+_ATTRIB_RE='agent[ei]?\b|claude|\bllm\b|assistant|assistente|automated|by hand|myself|personally|a mano|di persona|in prima persona'
+
+R_ATTRIBUTION=""
+lint_attribution() { # $1 = TEXT. Prints the lines that claim work without saying whose.
+  grep -nEi "$_CLAIM_RE" <<<"${1:-}" | grep -vEi "$_ATTRIB_RE" || true
+}
+
+gate_attribution() { # $1 = TEXT (never a filename). Fills R_ATTRIBUTION.
+  local lines r
+  lines="$(lint_attribution "${1:-}")"
+  R_ATTRIBUTION=""
+  if [ -z "$lines" ]; then
+    ok "R25 · no claim of work done that needs attributing"
+    return 0
+  fi
+  if ! { exec 3<>/dev/tty; } 2>/dev/null; then
+    # ⚠️ If the text ALREADY carries an explicit attribution somewhere (a paragraph at the
+    # end, as somebody following the convention by hand would write), stamping "not
+    # stated" over it would be a falsehood written by the tool that exists to prevent one.
+    # The lines are still shown: they are for whoever re-reads, not for deciding.
+    if grep -qEi "$_ATTRIB_RE" <<<"${1:-}"; then
+      R_ATTRIBUTION=""
+      warn "R25 · no terminal, but the text already says who did what. Lines to re-read:"
+      sed 's/^/      /' <<<"$lines"
+      return 0
+    fi
+    R_ATTRIBUTION='> *Attribution (R25): not stated - this text was produced without a terminal, so treat the claims above as unattributed.*'
+    warn "R25 · no terminal: these claims go out UNATTRIBUTED:"
+    sed 's/^/      /' <<<"$lines"
+    return 0
+  fi
+  { echo
+    printf '%sR25 - who did the work this text claims?%s\n' "$R_BOLD" "$R_NC"
+    echo "  Lines claiming work done without saying by whom:"
+    sed 's/^/      /' <<<"$lines"
+    echo
+    echo "  1) Me, by hand."
+    echo "  2) The agent I drive, on my machine. The decisions stay mine."
+    echo "  3) Mixed, and the text already distinguishes them line by line."
+    printf '> [1/2/3] '; } >&3
+  IFS= read -r r <&3 || r=""
+  exec 3>&-
+  case "$r" in
+    1) R_ATTRIBUTION='> *Attribution (R25): I read and checked this myself.*' ;;
+    2) R_ATTRIBUTION='> *Attribution (R25): the reading, the counts and the cross-checks in this message were done by the agent I drive, on my machine. What follows from them - the decisions - is mine.*' ;;
+    3) R_ATTRIBUTION='> *Attribution (R25): person and agent are distinguished inline - each claim above says which.*' ;;
+    *) R_ATTRIBUTION='> *Attribution (R25): not stated.*'
+       warn "R25 · no choice made: the text goes out unattributed." ;;
+  esac
+  ok "R25 · attribution recorded"
+}
+
+# Non-interactive variant, for text addressed to USERS rather than to the team (release
+# notes): name the lines and let the person decide. Blocking a stable release over a
+# sentence of prose would be disproportionate and would only teach people to derogate —
+# the same reasoning by which R07 does not block on a silent pull request.
+warn_attribution() { # $1 = TEXT, $2 = where
+  local lines; lines="$(lint_attribution "${1:-}")"
+  if [ -n "$lines" ]; then
+    warn "R25 · in $2 there are claims of work done that do not say whose:"
+    sed 's/^/      /' <<<"$lines"
+    echo "      -> attribute them in the text, or know that they go out like this."
+  else
+    ok "R25 · $2: nothing to attribute"
+  fi
+}
+
+# ── R02 applied to a TEXT — a secret pasted into an issue is as public as one in the repo
+# check-secrets.sh looks at git; a comment never passes through git. Same values, same
+# patterns, applied to the draft BEFORE it becomes a web page. Kept here as a library
+# function: the maintainer's local drafting tool uses it, and so can yours.
+lint_secrets_in_text() { # $1 = TEXT. Prints the findings; returns 1 if any.
+  local text="${1:-}" found="" d p
+  while IFS='|' read -r d p; do
+    case "$d" in ''|'#'*) continue ;; esac
+    grep -qEi -- "$p" <<<"$text" && found+="  · $d"$'\n'
+  done <<'PAT'
+PEM private key|BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY
+GitHub token|gh[pousr]_[A-Za-z0-9]{20,}
+JWT|\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}
+VIN (17 chars)|\b[A-HJ-NPR-Z0-9]{17}\b
+tUserId (long numeric)|\b3660[0-9]{14,}\b
+e-mail address|[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}
+international phone number|\+[1-9][0-9]{1,3}[ .-]?[0-9]{6,12}\b
+long hex string (key? id?)|\b[0-9a-f]{32,}\b
+private IPv4 address|\b(10|192\.168|172\.(1[6-9]|2[0-9]|3[01]))\.[0-9]{1,3}\.[0-9]{1,3}\b
+PAT
+  # Anything specific to one person or one machine lives in a gitignored file, because
+  # writing it here would publish exactly what it exists to catch.
+  if [ -f "$R_PRIVATE_PATTERNS" ]; then
+    while IFS='|' read -r d p; do
+      case "$d" in ''|'#'*) continue ;; esac
+      [ -n "$p" ] || continue
+      grep -qEi -- "$p" <<<"$text" && found+="  · $d (from tools/private-patterns.txt)"$'\n'
+    done < "$R_PRIVATE_PATTERNS"
+  fi
+  if [ -n "$found" ]; then
+    printf '%s' "$found"
+    return 1
+  fi
+  return 0
+}
+
+# ══════════════════════════════ CLI ══════════════════════════════
+_list() {
+  printf '%sRULEBOOK - omoda9-ha%s\n' "$R_BOLD" "$R_NC"
+  echo "Who may derogate: a person at a terminal, with a one-time code and a written reason."
+  echo "Agents: --authorized \"<what you were told>\", for NORMAL-severity rules only."
+  echo "Stated limit: a fake pty can imitate the terminal. See the comment at the top of this file."
+  echo
+  local r id s t f
+  for r in "${R_RULES[@]}"; do
+    IFS='|' read -r id s t f <<<"$r"
+    if [ "$s" = "HIGH" ]; then printf '%s%s%s %s[%s]%s' "$R_RED" "$R_BOLD" "$id" "$R_RED" "$s" "$R_NC"
+    else printf '%s%s%s [%s]' "$R_BOLD" "$id" "$R_NC" "$s"; fi
+    case "$id" in
+      R15|R16|R17|R18|R20|R24) printf '  %s(no gate: it is for the person working, not for the script)%s' "$R_YELLOW" "$R_NC" ;;
+      R26) printf '  %s(no gate here: it lives in the maintainer'"'"'s local drafting tool)%s' "$R_YELLOW" "$R_NC" ;;
+      R25) printf '  %s(a gate that asks and records: it does not verify)%s' "$R_YELLOW" "$R_NC" ;;
+      R06|R13) printf '  %s(warning, not a block)%s' "$R_YELLOW" "$R_NC" ;;
+    esac
+    case "$f" in house*) printf '  %s(HOUSE RULE: no prose behind it in this repository)%s' "$R_YELLOW" "$R_NC" ;; esac
+    echo; echo "   $t"; printf '   %ssource:%s %s\n\n' "$R_BLUE" "$R_NC" "$f"
+  done
+}
+
+_check() {
+  R_PREFLIGHT=1
+  printf '%sPreflight - read-only, no derogation is ever asked for%s\n\n' "$R_BOLD" "$R_NC"
+  printf 'branch: %s · HEAD: %s\n' "$(git -C "$R_ROOT" rev-parse --abbrev-ref HEAD)" "$(git -C "$R_ROOT" rev-parse --short HEAD)"
+  local dirty; dirty="$(git -C "$R_ROOT" status --porcelain | wc -l)"
+  [ "$dirty" -gt 0 ] && warn "$dirty modified files, not committed" || ok "clean tree"
+  echo
+  local g
+  for g in gate_tools gate_private_material_out gate_tools_visible gate_stage_clean gate_core_without_ha \
+           gate_no_model_names gate_token_not_in_git_config; do
+    ( $g ) || printf '%s   ^ %s is not satisfied%s\n' "$R_RED" "$g" "$R_NC"
+  done
+  # ⚠️ gate_changelog is deliberately NOT in that list. It belongs to a release: on a
+  # freshly released master the '[Non rilasciato]' section is legitimately empty, and a
+  # preflight that comes out red every single day is a preflight people stop reading —
+  # which is the same failure mode as a gate that always fires. Here it is reported.
+  local unreleased
+  unreleased="$(awk '/^## \[Non rilasciato\]/{f=1;next} /^## /{f=0} f' "$R_ROOT/CHANGELOG.md" | grep -cE '^[-*]' || true)"
+  if [ "${unreleased:-0}" -eq 0 ]; then
+    ok "changelog · nothing unreleased yet (R04 is checked when you cut a release)"
+  else
+    ok "changelog · ${unreleased} unreleased entries (R04 checks both languages at release time)"
+  fi
+  ( gate_no_trailer_in_commits origin/master ) || printf '%s   ^ AI trailers present%s\n' "$R_RED" "$R_NC"
+  echo
+  echo "(the suite and the secret gate run from ./tools/pr.sh or ./tools/release.sh: they are slow)"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  case "${1:-list}" in
+    list|rules)  _list ;;
+    check)       _check ;;
+    log)         [ -f "$DEROGATIONS_LOG" ] && cat "$DEROGATIONS_LOG" || echo "no derogation has ever been granted." ;;
+    *) echo "Usage: $0 [list|check|log]" >&2; exit 1 ;;
+  esac
+fi


### PR DESCRIPTION
## What changes, and why

`tools/` — the rules of this repository written so a machine can check them, which until
today existed only on my machine. @drake69 asked for it on #25 and the argument was right:
a rule only one machine can enforce is a rule the other three of you are guessing at.

- `tools/rules.sh` — 26 numbered rules, each with its source and its severity, plus the
  gates. `./tools/rules.sh list` prints the table; `check` is a read-only preflight.
- `tools/pr.sh` — lands a change: branch, gates in order, push, pull request filled from
  the repository's own template. The order matters — the secret gate runs *after* the
  commit and *before* the push, because against staged-only changes it sees nothing.
- `tools/release.sh` — `status` · `prepare` · `publish` · `abort`.
- `tools/check-secrets.sh` — every confidential pattern, over the **whole history** and
  the working tree, including files git has never seen.
- `tools/README.md` — the table @drake69 called the interesting half: every `R` number
  against the paragraph in `CONTRIBUTING.md` or `AGENTS.md` it comes from.

**None of it is required.** `git push` and `gh pr create` are in `AGENTS.md` and always
will be. These just refuse to let you forget something.

## What I took out before publishing it

This arrived as a pull request rather than a paste because it needed a review pass, and
the review found things worth naming:

- **My own e-mail address was hard-coded in `check-secrets.sh`**, in the line meant to
  stop it being published — and the pattern does not match itself, so the gate would have
  published it and said PASS. Anything personal now lives in `tools/private-patterns.txt`,
  which is gitignored, with a committed example.
- **`/root/…`, `/media/…`, Proxmox and VM commands** were written into two of the scripts.
  Once tracked they also made the info-disclosure check report *itself*, five hits, every
  run — a warning that always fires is a warning people stop reading. The patterns are now
  written so they cannot match themselves.
- **Everything assumed the scripts sat at the top of the tree.** Moved into `tools/` they
  reported that `core/` had ceased to exist. The root is resolved through git now.
- **The rule that kept this tooling out of the repository (`R14`) blocked the pull request
  that publishes it.** Verified by running it. Rewritten: private material stays out, the
  tooling does not.
- **GNU-only constructs** — `grep -oP`, `sed -i`, `base64 -w0`, `date -Is` — are gone.
  `base64 -w0` was in the push path, so on macOS this could not push at all.
- **The suite gate hard-failed when no local interpreter had pytest**, which is stricter
  than `AGENTS.md`, and that file explicitly allows skipping it and letting CI be the gate.
  It now warns, and the pull request body says the suite did not run locally.
- **Forks**: `pr.sh` now sends `owner:branch` as the head when `origin` is not this
  repository.
- **Every pull request opened without a terminal was labelled `unverified-hardware`**,
  including one that changes no runtime behaviour — a false line in the next release
  notes. `--evidence backend|not-mine|none` states it instead. It cannot say *verified on
  hardware*: that answer means somebody watched a car.

One more was found by this very pull request, on the first real run: `pr.sh` treats a
different `origin` slug as a fork and sends `owner:branch` as the head. But **a renamed or
transferred repository is not a fork** — this one moved to the organisation and my remote
still carried the old owner, so GitHub answered `422 head invalid` with the branch already
pushed and nothing to show for it. The API resolves the old name through a 301, so it now
asks before deciding.

And once that was fixed it produced the wrong title: with `--continue` and no message the
title came from `git log -1`, so the two-line follow-up above became the name of the whole
pull request. It takes the first commit beyond the base now. Those are commits here, left visible rather
than folded away: a tool for opening pull requests that had never opened one is worth
knowing about, and so is the fact that CI caught what my own review did not.

And CI found the one the audit missed. `R14` — *the tooling stays out of the repository* —
is written down **twice**: in the shell gate, which I had rewritten, and in
`tests/test_repo_hygiene.py`, which I had not. It matches by basename, so `tools/release.sh`
failed the very pull request that publishes the tooling. Those names are now forbidden only
at the **root**, which is where the stale private copies actually sit.

That test had also been skipping itself: it asks whether `.git` is a *directory*, and inside
a git worktree `.git` is a *file* pointing at the common directory. Five tests had quietly
not been running for anyone who works in a worktree — which is why this passed locally as
`610 passed, 5 skipped` and failed in CI. It is `615 passed, 0 skipped` now.

## What it found on its first honest run

Two machine paths of mine already committed in `core/commands.py` and `tests/fixtures.py`.
Comments only, and they are scrubbed here. Two more (`/root/.local/…` in `config_flow.py`
and `tls_client.py`) are *correct* — that is where pip puts a package inside the Home
Assistant container — so the checker has one explicit allowance for them.

Both strings stay in the published history, where they cannot be removed without rewriting
it. Scrubbing the current text stops them spreading; it does not undo the past, and I would
rather say that than imply otherwise.

## Two things to argue with

**`R04` (a human, bilingual changelog) and `R05` (one stable release per fortnight) are
house rules with blocking gates.** They are my practice, not a decision anybody agreed to,
and if you cut a release they will stop you. They are marked **house rule** in the table
rather than dressed up as project rules. If the group wants them they belong in
`CONTRIBUTING.md` as prose — a separate pull request — and if it does not, delete the
gates. Same for `R15`, `R17` and `R18`, which have no gate at all.

**`R25` asks, it does not verify.** No program knows who really read a file. It recognises
explicit first person and, when the text does not say whose work it is, makes you answer
and writes the answer at the bottom. Calling it verification would be the exact thing this
project forbids.

## What is deliberately not here

The comment tool and the deploy script. The first exists because I do not read code and
should not approve English text blind, so it demands a summary in Italian first — that is
one person's problem, not the project's. The second copies the component into one
particular VM. `R26` belongs to the comment tool, so it is listed with no gate rather than
quietly dropped: a hole in the numbering would confuse more than an honest line.

## About the gate itself

A derogation needs a person at a terminal, a one-time code printed at that moment, and a
written reason, and it is refused if the register cannot be written. **It is a high kerb,
not a wall**: `script -qec` or `expect` can read the code and type it back, and that is
said at the top of the file rather than left for somebody to discover. There is a second,
narrower door — `--authorized "<what you were told>"` — because most of us drive an agent
and an agent has no terminal; it opens only for NORMAL-severity rules, and it records the
sentence word for word. It cannot verify that sentence, and it says so.

## Evidence

**No runtime behaviour** — tooling, documentation and two comment lines. Nothing a user
can see changes.

> *Attribution (R25): the audit, the rewrite and the testing in this pull request were done
> by the agent I drive, on my machine, and I have not read the diff line by line myself.
> The decisions — what to publish, what to keep private, which rules to mark as mine
> rather than the project's — are mine.*

## Checks

- [x] Suite green — `615 passed, 0 skipped`, run by the R12 gate itself
- [x] Entity count unchanged — `tests/test_entity_count.py`, inside the suite
- [x] No VIN, token, certificate, account id or raw capture — `tools/check-secrets.sh`
      over the whole history: `RESULT: PASS`
- [x] Fails open: nothing here can take away a function that worked for somebody — no
      runtime code is touched
- [ ] Design docs updated if this contradicts them — n/a

Also exercised in a sandbox with a fake remote, never against this repository: the full
`pr.sh` run to the point of opening the pull request, `release.sh status`, the version bump
and changelog dating, the archive builder, and both derogation paths (a NORMAL rule waived
and recorded, a HIGH rule refused).

## Read requested

This touches `custom_components/omoda9/core/commands.py`, which `CONTRIBUTING.md` puts in
the shared-code row — a comment, but the rule does not have a special case for comments and
I would rather not invent one. The merge is not blocked (R06/R20).

@drake69 — this is the thing you asked for. The part I would most like argued with is the
`R`-to-prose table in `tools/README.md`: several rules turned out to have nothing behind them
in this repository, and I would rather you disagree with how I labelled them than inherit
them by default.
