### PR TITLE
docs+test: close issues on merge, and never leave a language behind

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,14 @@ someone for whom it worked.
 refactor. If the entity count changes, that is a deliberate, announced change —
 and the test will stop you first.
 
+**Never leave a language behind.** Anything that adds or renames a user-visible label or
+an error message touches **three** files: `strings.json`, `translations/en.json` and
+`translations/it.json`. A key present in one and missing in another produces an entity
+with **no name at all** — but only for the people using that language, so whoever wrote
+the change never sees it. `tests/test_traduzioni_complete.py` compares the key sets and
+fails if they diverge; it checks that you did not forget a file, not that you translated
+anything, so a key is only really done when the text is in the right language.
+
 **No Home Assistant imports in `core/`.** The protocol logic must be exercisable
 without Home Assistant installed. This is what lets the sandbox test a change
 without an instance, and it is the rule the whole suite rests on.
@@ -200,6 +208,15 @@ CI be the gate — that is why CI exists — but say so in the pull request.
 git push -u origin HEAD
 gh pr create --fill
 ```
+
+**Put `Closes #12` in the body when the pull request finishes an issue.** GitHub then
+closes it on merge, and links the two forever. Without it somebody has to remember, and
+nobody does: on 24 August this repository had fifteen issues of which exactly one was
+closed — by the single pull request that carried the line.
+
+Use it only when the merge really finishes the issue. If it fixes part of one, write
+`Relates to #12` and say in the body what is left, so the issue outlives the merge instead
+of being closed on a half-answer.
 
 Then fill in the field-test block in the template. If you did not test on
 hardware, say it there rather than leaving it blank:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,43 @@ adding one, you have found an architecture problem: say so instead of encoding i
 **The suite stays green.** Not "green after a follow-up" — green in the pull
 request that changes the behaviour.
 
+## Before you write a rule, ask what would enforce it
+
+You will be asked to write rules — into this file, into `CONTRIBUTING.md`, into a pull
+request description. **A written rule is free and a tool is not**, so the gap between what
+the documents claim and what the repository actually permits widens on its own, silently,
+until somebody tries to follow the rule and hits a wall.
+
+When that happens it does not look like a rule being broken. It looks like a person not
+bothering.
+
+This project collected five of these in a single day, 24 August 2026:
+
+- `CONTRIBUTING.md` said the review that counts is somebody running the change on their own
+  car — while a pull request produced **nothing anyone could install**;
+- both documents told people to use the labels `beta`, `unverified-hardware` and
+  `merged-unread`, and **none of the three existed**. Two maintainers had just agreed to use
+  one: they would have got an error;
+- a maintainer proposed GitHub Projects while **Projects were disabled** and he had
+  read-only access;
+- another had built the executable form of these rules on his own machine, so his pull
+  requests were better documented than everyone else's — not through more care, but because
+  he had a gate and nobody else did;
+- and `AGENTS.md` forbids AI co-authorship trailers while one maintainer's tooling adds one
+  to every commit by default.
+
+So, when you write a rule:
+
+- **name the thing that enforces it** — a test, a CI job, a label that exists, a template
+  field. If the honest answer is "whoever reads this will remember", it is not a rule, it is
+  a hope, and hopes should be written as advice rather than as requirements;
+- **ship it in the same change.** `tests/test_traduzioni_complete.py` arrived in the same
+  commit as the rule about the three language files, and it started green — a rule that is
+  already true, pinned so it cannot quietly stop being true;
+- **check the thing exists before telling somebody to use it.** Open the settings, list the
+  labels, read the permissions. It takes a minute and it is the difference between an
+  instruction and an error message.
+
 ## The discipline that matters most: don't overstate evidence
 
 Half of this codebase is written for cars the author does not own. That is

--- a/tests/test_traduzioni_complete.py
+++ b/tests/test_traduzioni_complete.py
@@ -1,0 +1,59 @@
+"""Le tre lingue devono portare le stesse chiavi.
+
+`strings.json` è la sorgente che Home Assistant usa per generare le traduzioni;
+`translations/en.json` e `translations/it.json` sono quelle servite all'utente. Se una
+chiave esiste in una e manca in un'altra, l'entità compare **senza nome** — o con la
+chiave grezza — soltanto per chi ha quella lingua, e chi sviluppa non se ne accorge
+perché la sua è quella completa.
+
+Non è ipotetico: portando i contatori di energia dalla linea fork il 2026-08-24, quella
+linea aveva `en.json` e non `it.json`. Copiare senza guardare avrebbe dato tre entità
+senza nome a tutti gli utenti italiani.
+
+⚠️ Questo test guarda le CHIAVI, non le TRADUZIONI. Un `name` copiato in inglese dentro
+`it.json` lo passa: dice che non hai dimenticato un file, non che hai tradotto.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+PKG = Path(__file__).resolve().parents[1] / "custom_components" / "omoda9"
+FILES = {
+    "strings.json": PKG / "strings.json",
+    "translations/en.json": PKG / "translations" / "en.json",
+    "translations/it.json": PKG / "translations" / "it.json",
+}
+
+
+def _chiavi(path: Path) -> set[str]:
+    """Tutte le chiavi foglia, come percorsi puntati: `entity.sensor.batteria.name`."""
+    def cammina(nodo, prefisso=""):
+        if isinstance(nodo, dict):
+            for k, v in nodo.items():
+                yield from cammina(v, f"{prefisso}.{k}" if prefisso else k)
+        else:
+            yield prefisso
+
+    return set(cammina(json.loads(path.read_text(encoding="utf-8"))))
+
+
+@pytest.mark.parametrize("nome", [n for n in FILES if n != "strings.json"])
+def test_ogni_lingua_ha_le_chiavi_di_strings(nome):
+    """`strings.json` è il riferimento: ogni lingua deve coprirlo per intero."""
+    rif = _chiavi(FILES["strings.json"])
+    lingua = _chiavi(FILES[nome])
+
+    mancanti = sorted(rif - lingua)
+    assert not mancanti, (
+        f"{nome} non ha {len(mancanti)} chiavi presenti in strings.json — chi usa quella "
+        f"lingua vedrà entità senza nome: {mancanti[:12]}"
+    )
+
+    in_piu = sorted(lingua - rif)
+    assert not in_piu, (
+        f"{nome} ha {len(in_piu)} chiavi che strings.json non dichiara: o sono rimaste da "
+        f"una rimozione, o vanno aggiunte anche lì: {in_piu[:12]}"
+    )


### PR DESCRIPTION
Two rules for `AGENTS.md`, and the second arrives with the check that enforces it rather than as a request to remember.

## `Closes #N`

**Correcting my own evidence for this, having checked instead of assumed.** I opened this saying that fifteen issues were open and one closed, implying the others lacked the line. They do not: #14, #16, #17, #21 and #33 all carry `Closes`/`Fixes`, and @Caslinovich used `Relates to #1` on #25 and #26 — which is precisely the distinction this rule asks for, applied before anyone wrote it down. The issues are open because those pull requests have not merged yet, not because anybody forgot.

So this rule is not a correction of current practice. It is writing down what four of us already do, so that it survives the fifth person and the tired evening.

The rule says to use it only when the merge really finishes the issue. A partial fix gets `Relates to #N` and a sentence about what is left, so the issue outlives the merge instead of being closed on a half-answer. @Caslinovich, #25 and #26 are exactly that case: both relate to #1 and neither finishes it, since rear defrost (`232`) and the seat category (`214`) are still denied on that car.

## Never leave a language behind

A label or an error message lives in **three** files: `strings.json`, `translations/en.json`, `translations/it.json`. A key present in one and missing in another produces an entity with **no name at all** — but only for the people using that language, so whoever wrote the change never sees it.

Not hypothetical. The fork line carries `en.json` and no `it.json`; porting the charging-energy counters from it without looking would have given every Italian user three unnamed entities.

`tests/test_traduzioni_complete.py` compares the key sets across the three files. **It starts green** — 185 leaf keys, identical in all three — so it is a ratchet rather than a cleanup, in the sense of #6: a rule that is already true, written down so it cannot quietly stop being true.

It deliberately checks **keys and not text**, and the docstring says so: a `name` left in English inside `it.json` passes. A test that appeared to verify translation quality would get trusted for something it cannot do, which is worse than not having it.

## A third rule, added after the fact — and it is the one that produced the other two

`9ec70b8` adds a section to `AGENTS.md`: **before you write a rule, ask what would enforce it.**

It was missing from this branch and that was the joke at my expense. The reasoning below was sitting in a pull request description, which is exactly where a rule goes to be forgotten. The section names the five failures of 24 August, because the abstraction on its own would not survive contact with a tired evening, and ends with three instructions: name the thing that enforces the rule, ship it in the same change, and check the thing exists before telling somebody to use it.

@Caslinovich — the fifth item on that list is that this file forbids AI co-authorship trailers while your commits carry one, because Claude Code adds it by default. I am naming it as an instance of the pattern rather than as a complaint: it is precisely a rule losing to a tool, and nothing in the published history should be rewritten to fix it — `blame` and `bisect` on that history are why we chose this line as the base.

## Why these two and why now

Both are the same shape as the thing this project kept running into yesterday — a standard that is written down while the thing that makes it hold is missing. Five instances in one day, from the review rule that no pull request could satisfy to the three labels the documents told people to use and that did not exist. So the translation rule ships with its test in the same commit, and the `Closes` rule is a line in a template rather than a habit somebody has to acquire.

*Per the convention: the check that the three files currently agree, and the survey of which issues are closed, were run by the agent I drive. Both rules were asked for by me.*

