### PR TITLE
docs: write the code in English, from here on rather than retroactively

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,9 +89,17 @@ translating them would destroy exactly what makes them worth reading. So:
 **Two things this rule does not cover**, deliberately:
 
 - **entity translation keys and `entity_id` slugs** (`autonomia_benzina`,
-  `carburante_residuo`, …). Those are user-visible identifiers: renaming one changes an
-  `entity_id` and breaks somebody's automations, dashboards and statistics history. They
-  change only in a deliberate, announced release — never as a side effect of tidying;
+  `carburante_residuo`, …), of which **91 out of 107 are currently Italian**. Those are
+  user-visible identifiers: renaming one changes an `entity_id` and breaks somebody's
+  automations, dashboards and long-term statistics. Never as a side effect of tidying.
+
+  **They are not excluded forever, though — they are booked for the one moment when they
+  are free.** The HA domain rename (`omoda9` → `chery_connect`) changes every `entity_id`
+  in the integration anyway, and costs every user one reconfiguration. Renaming the slug at
+  the same time costs them nothing on top of a migration they are already doing; renaming it
+  at any other time is a second break for no reason. So the whole set moves **in that
+  release and in no other**, listed in its notes, with an old → new table so people can fix
+  their automations in one pass. See step 3 of #10;
 - **the user-facing Italian in `translations/it.json` and in command-result text**, which is
   a translation and is supposed to be in Italian.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,39 @@ people expect. Redact before you paste. Fixture data is synthetic.
 at runtime — not a new branch, class, or `if model == …`. If you find yourself
 adding one, you have found an architecture problem: say so instead of encoding it.
 
+**Write the code in English — identifiers, comments and docstrings.** The people
+maintaining this live in Italy, the UK, Denmark, Austria and Poland, and the prose around
+the project is already English: commit messages, pull requests, `CONTRIBUTING.md`, this
+file. The reasoning *inside* the code is the one place that is not, and it is the place a
+new maintainer has to understand before they can change anything safely.
+
+**Going forward, not retroactively.** Roughly 1,400 comments and 290 docstrings here are in
+Italian, and they are the best asset this codebase has — measured, dated, specific. Machine
+translating them would destroy exactly what makes them worth reading. So:
+
+- **new code is English**, including variable and function names;
+- **a block you are already editing becomes English** as part of that change — if you touch
+  the lines, translate the paragraph you touched, and do it yourself rather than with a
+  tool that will smooth away the detail;
+- **everything else stays as it is** until somebody has a reason to touch it. A rule that
+  makes the whole repository non-compliant on the day it is written gets ignored by the
+  end of the week.
+
+**Two things this rule does not cover**, deliberately:
+
+- **entity translation keys and `entity_id` slugs** (`autonomia_benzina`,
+  `carburante_residuo`, …). Those are user-visible identifiers: renaming one changes an
+  `entity_id` and breaks somebody's automations, dashboards and statistics history. They
+  change only in a deliberate, announced release — never as a side effect of tidying;
+- **the user-facing Italian in `translations/it.json` and in command-result text**, which is
+  a translation and is supposed to be in Italian.
+
+**What enforces it: a reader, not a test.** No check can tell whether a comment is English,
+so this is one of the few rules here that depends on somebody noticing in review. That is
+stated rather than hidden — see *Before you write a rule, ask what would enforce it* above.
+The one automated piece is the hook that already refuses non-English commit messages and
+pull request text.
+
 **The suite stays green.** Not "green after a follow-up" — green in the pull
 request that changes the behaviour.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,19 @@ translating them would destroy exactly what makes them worth reading. So:
 - **the user-facing Italian in `translations/it.json` and in command-result text**, which is
   a translation and is supposed to be in Italian.
 
+**The same rule covers everything you write on GitHub**: issues and their titles,
+comments, review comments — not only the commit messages and pull request text the hook
+below already refuses. Not as a matter of taste, but of who can read the queue.
+@GurliGebis is building the merged repository and offered to handle the HACS
+default-store submission, and has no Italian; @JackRonan, @ThomasMeyer1970, @Sisku and
+@kowi4 all write in English. An Italian title on a pull request asks them to review code
+through a thread they cannot read, and today several of the open ones do exactly that.
+
+The exception is the one directly above, and the test is **who the sentence is addressed
+to**: a collaborator, or somebody driving the car. `translations/it.json`, the Italian
+half of `CHANGELOG.md` and command-result text stay Italian — they are translations doing
+their job, and they are not to be "fixed".
+
 **What enforces it: a reader, not a test.** No check can tell whether a comment is English,
 so this is one of the few rules here that depends on somebody noticing in review. That is
 stated rather than hidden — see *Before you write a rule, ask what would enforce it* above.


### PR DESCRIPTION
The prose around this project is already English — commit messages, pull requests, `CONTRIBUTING.md`, `AGENTS.md`. The reasoning **inside** the code is not, and that is the one place a new maintainer has to understand before they can change anything safely.

Five of the people maintaining or testing this do not read Italian: @JackRonan (UK), @GurliGebis (DK), @ThomasMeyer1970 (AT), @kowi4 (PL), @divisl.

## Measured before writing it, because the numbers decide the shape

| | Italian |
|---|---|
| identifiers | **116 of 1978** (5%) |
| comments | **1438 of 2080** (69%) |
| docstrings | **289 of 345** (83%) |

The names are already almost entirely English. What is Italian is the *explanation* — and those explanations are the best asset this codebase has. The docstrings in `core/routing.py`, `core/permessi.py` and `core/pin_lockout.py` are the reason somebody can pick this up at all: they carry measurements, dates, times to the second, and the reasoning behind decisions that would otherwise look arbitrary.

**A correction to how I first put this.** I wrote that translating them would destroy @Caslinovich's writing. That is not what they are: none of the four of us writes this by hand, so those blocks were produced by the agent he drives, in Italian because that is the language he works in. Which means going forward costs him one line of instruction to his own agent rather than a change of habit — and re-expressing an existing block in English, with the original measurements to hand, is something an agent does without losing the detail. The premise I built the scope on was weaker than I stated it.

## So the rule is forward-looking

- **new code is English**, including variable and function names;
- **a block you are already editing becomes English** as part of that edit — by hand, not with a tool;
- **everything else stays** until somebody has a reason to touch it.

A rule that makes the whole repository non-compliant on the day it is written is ignored by the end of the week. This one asks for something anybody can do on their next pull request without stopping to run a migration first — the file converts itself, gradually, driven by whoever is already in there.

**And the real reason not to sweep it in one go** is not the writing, it is the history. Rewriting ~1700 explanatory blocks would put a single commit on top of every line of reasoning in this project, and `git blame` on that reasoning is precisely why we chose this repository as the base rather than the merged one — that decision cost us the merged repo's conveniences to keep blame and bisect intact. A sweep would spend it. It would also be a diff nobody could review, which is the failure this project spends most of its rules avoiding.

## Two exclusions, deliberate

**Entity translation keys and `entity_id` slugs** — `autonomia_benzina`, `carburante_residuo` and the rest. Never as a side effect of tidying: renaming one changes an `entity_id` and breaks somebody's automations, dashboards and long-term statistics.

But **not excluded forever, and `9edab53` says so**, because "never" would leave the integration permanently half-translated: **91 of the 107 entity keys are Italian** — essentially the whole user-visible surface.

There is exactly one moment when renaming them is free. The domain rename (`omoda9` → `chery_connect`) changes every `entity_id` anyway and already costs each user one reconfiguration; doing the slugs in the same release adds nothing to a migration they are performing regardless. At any other time it is a second break for no reason — the same arithmetic that says somebody still on the retired line should wait for that release rather than migrate twice.

So the whole set moves **in that release and no other**, listed in the notes with an old → new table, so people fix their automations in one pass instead of finding them broken one card at a time. Step 3 of #10.

**The Italian in `translations/it.json` and in command-result text** is a translation. It is supposed to be Italian.

## Enforced by a reader, and the rule says so

No check can tell whether a comment is English, so this is one of the few rules here that depends on somebody noticing in review. Stating that is the point of the section it sits under — a rule whose enforcement is "somebody will remember" is a hope, and hopes should be labelled rather than dressed up as requirements. The one automated piece already exists: the hook that refuses non-English commit messages and pull request text, which I have tripped twice today.

## What I would like argued

@Caslinovich, most of the Italian in here came out of your investigations, so you are the person best placed to say whether English costs anything real. My guess is that it does not — the precision lives in the measurements, and those are numbers and timestamps that survive any language. But it is a guess about your workflow rather than mine.

If you think the trade is wrong, "identifiers and new files in English, explanations in whatever language gets them right" is a defensible rule too, and I would rather have the one you will actually follow than the one that reads better.

*Per the convention: the counts above were produced by the agent I drive, over the whole package. The decision to scope the rule forward rather than retroactively, and the two exclusions, are mine.*
