### PR TITLE
ci(beta): cut pre-releases from master only, because HACS offers the newest one

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,134 +1,79 @@
 name: Beta
 
-# Una pre-release INSTALLABILE tagliata da una pull request, per farla provare su
-# un'auto vera prima che il cambiamento entri.
+# An INSTALLABLE pre-release cut from `master`, so the assembled thing can be tried on a
+# real car before it is declared stable.
 #
-# Perché esiste. Il gate di questo progetto non è il merge ma la STABILE, e la
-# review di chi non programma è la prova sul campo sulla propria auto. Perché
-# quella regola sia esigibile, chi ha l'auto deve poter installare la PR — e fino
-# a oggi non poteva: `hacs.json` dichiara `zip_release`, quindi HACS installa solo
-# da una release che porta allegato `omoda9.zip`, e quell'asset veniva costruito e
-# caricato a mano una volta per release. L'unica strada era scaricare un branch e
-# copiare i file in `custom_components/` a mano: esattamente la barriera che tiene
-# fuori le persone la cui review vale di più.
+# Why it exists. The gate of this project is not the merge but the STABLE release, and the
+# review of someone who does not program is the field test on their own car. For that rule
+# to be exigible, the person with the car has to be able to install the code — and until
+# this workflow existed they could not: `hacs.json` declares `zip_release`, so HACS installs
+# only from a release carrying an `omoda9.zip` asset, and that asset was built and uploaded
+# by hand once per release. The only other route was cloning a branch and copying files into
+# `custom_components/` — exactly the barrier that filters out the people whose review is
+# worth most.
 #
-# Come si avvia: si mette l'etichetta `beta` sulla PR. Due tocchi dal browser di un
-# telefono — è deliberato, perché chi deve poterla chiedere non sempre ha un
-# computer sotto mano. `workflow_dispatch` resta come uscita di sicurezza.
+# WHY ONLY FROM `master`, AND NOT FROM A PULL REQUEST. This was tried the other way first,
+# on 24 August 2026: four pre-releases cut from four different branches, numbered beta.1 to
+# beta.4. It does not work, and the reason is in HACS itself
+# (`custom_components/hacs/repositories/base.py`, lines 1103-1114 and 385-388):
 #
-# E si avvia anche SENZA una PR: `workflow_dispatch` col campo vuoto taglia la beta
-# da `master`. Serve a collaudare l'INSIEME, che è la cosa che una beta per-PR non
-# può fare: quella prova «master di quando ho aperto il branch, più una modifica»,
-# mai le modifiche una accanto all'altra. E i guasti di questo progetto vivono lì —
-# il conteggio delle entità, le tre liste di traduzione che devono coincidere, le
-# capability: sono proprietà CONGIUNTE, che nessuna singola PR esercita. Il ciclo
-# che serve è: si mergia un lotto, si taglia una beta da master, la si prova su
-# un'auto vera, si passa al lotto dopo.
+#     releases = await self.get_releases(prerelease=True, returnlimit=30)   # GET /releases
+#     for release in releases:
+#         if release.draft: continue
+#         elif release.prerelease:
+#             if self.data.prerelease is None:
+#                 self.data.prerelease = release.tag_name    # the FIRST one it meets
+#     ...
+#     if self.data.show_beta and self.data.prerelease is not None:
+#         available = self.data.prerelease
 #
-# Chi può avviarla: solo chi ha accesso in scrittura, perché è GitHub a decidere
-# chi può etichettare. I tester non avviano niente: ricevono un link e installano.
+# `GET /releases` returns newest-created first, and HACS never sorts. So HACS offers the
+# most recently PUBLISHED pre-release, not the highest version — the version number does not
+# enter the decision at all. A tester with "show beta versions" on does not choose which
+# build they get: they get the last one published, whatever branch it came from. Cutting
+# betas from branches therefore produces a counter that rises while the content moves
+# sideways: beta.4 contained one pull request and none of the three before it.
+#
+# The consequence, and the rule this file now enforces: every published pre-release must be
+# coherent on its own, and only a build from `master` is. That also happens to be the thing
+# a per-PR beta could never do — test the changes NEXT TO EACH OTHER. The failures of this
+# project live exactly there: the entity count, the three translation lists that must agree,
+# the capabilities. Those are JOINT properties that no single pull request exercises.
+#
+# The cycle this supports: merge a batch, cut a beta from master, try it on a real car, move
+# to the next batch.
+#
+# What was lost with the per-PR build, and is not yet replaced: putting a change written for
+# a car nobody here owns in front of its owner BEFORE it is merged. See the discussion on
+# #43 — it needs a shape that is not a published pre-release of this repository.
+#
+# Who can start it: only people with write access, since only they can run a workflow.
+# Testers start nothing: they receive a link and install.
 
 on:
-  pull_request:
-    types: [opened, labeled]
   workflow_dispatch:
-    inputs:
-      pr:
-        description: "Numero della PR da cui tagliare la beta — vuoto = da master"
-        required: false
-        type: string
 
 permissions:
-  contents: write        # creare il tag e la pre-release
-  pull-requests: write   # scrivere il commento sulla PR
+  contents: write        # create the tag and the pre-release
 
 jobs:
-  # Il meccanismo si annuncia da solo nel momento in cui serve. Una riga in
-  # CONTRIBUTING.md non la rilegge nessuno: chi apre una PR fra due settimane non
-  # saprebbe che la beta si può chiedere, e saremmo di nuovo senza tester.
-  suggerimento:
-    if: >-
-      github.event_name == 'pull_request' &&
-      github.event.action == 'opened' &&
-      github.event.pull_request.user.type != 'Bot'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Ricorda come si chiede una beta
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          # Solo se la PR tocca il codice dell'integrazione. Su una PR di soli
-          # documenti il suggerimento sarebbe un falso allarme, e un avviso che
-          # compare quando non serve smette di essere letto quando serve.
-          if ! gh pr diff "$PR" --repo "$GITHUB_REPOSITORY" --name-only \
-               | grep -q '^custom_components/'; then
-            echo "PR di soli documenti: nessun suggerimento."
-            exit 0
-          fi
-
-          gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --body \
-          "Per far provare questa modifica sull'auto di qualcuno, metti l'etichetta \`beta\` a questa PR: esce una pre-release installabile da HACS (*Show beta versions*), e chi ha la vettura giusta può dire se l'auto ha fatto davvero quello che diciamo.
-
-          Serve soprattutto quando il cambiamento riguarda un modello che tu non possiedi: lì la tua prova non può falsificarlo, e la sola review possibile è quella di chi ha quella macchina."
-
   beta:
-    # MAI da un fork. Quello zip finisce installato in istanze Home Assistant che
-    # contengono le credenziali dell'auto di qualcuno, e pubblicato come release del
-    # repo canonico ha tutta l'aria dell'ufficiale. Da un fork la beta la taglia un
-    # membro a mano, dopo aver guardato cosa c'è dentro.
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.action == 'labeled' &&
-       github.event.label.name == 'beta' &&
-       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
-      - name: Risolvi il bersaglio (una PR, oppure master) e rifiuta i fork
+      - name: Resolve the target — the head of master
         id: pr
         env:
           GH_TOKEN: ${{ github.token }}
-          NUM: ${{ github.event.pull_request.number || inputs.pr }}
         run: |
           set -euo pipefail
-
-          # Campo vuoto = build d'insieme da master. Nessuna PR da risolvere e nessun
-          # fork da rifiutare: `master` è per definizione un branch di questo repo, e ci
-          # si arriva solo passando dalla protezione del branch.
-          if [ -z "${NUM:-}" ]; then
-            sha=$(gh api "repos/$GITHUB_REPOSITORY/commits/master" --jq .sha)
-            {
-              echo "numero="
-              echo "sha=$sha"
-              echo "titolo=tutto quello che è entrato finora"
-              echo "url=https://github.com/$GITHUB_REPOSITORY/commits/master"
-            } >> "$GITHUB_OUTPUT"
-            echo "Build d'insieme da master: $sha"
-            exit 0
-          fi
-
-          dati=$(gh pr view "$NUM" --repo "$GITHUB_REPOSITORY" \
-                 --json headRefOid,headRepository,headRepositoryOwner,title,url)
-          sha=$(echo "$dati"   | jq -r .headRefOid)
-          owner=$(echo "$dati" | jq -r .headRepositoryOwner.login)
-          nome=$(echo "$dati"  | jq -r .headRepository.name)
-          titolo=$(echo "$dati" | jq -r .title)
-          url=$(echo "$dati"   | jq -r .url)
-
-          # Il guard vale anche per workflow_dispatch, dove l'espressione `if` del
-          # job non ha un evento PR da cui leggere il repo di provenienza.
-          if [ "$owner/$nome" != "$GITHUB_REPOSITORY" ]; then
-            echo "::error::La PR #$NUM arriva dal fork $owner/$nome. Le beta si tagliano solo da branch di questo repo."
-            exit 1
-          fi
-
+          # No pull request to resolve and no fork to reject: `master` is by definition a
+          # branch of this repository, and the only way into it is through branch protection.
+          sha=$(gh api "repos/$GITHUB_REPOSITORY/commits/master" --jq .sha)
           {
-            echo "numero=$NUM"
             echo "sha=$sha"
-            echo "titolo=$titolo"
-            echo "url=$url"
+            echo "titolo=tutto quello che è entrato finora"
           } >> "$GITHUB_OUTPUT"
+          echo "Build d'insieme da master: $sha"
 
       - uses: actions/checkout@v7
         with:
@@ -159,15 +104,14 @@ jobs:
           if [ -n "$stabile" ] && [ "$stabile" != "null" ]; then
             piu_alta=$(printf '%s\n%s\n' "$base" "$stabile" | sort -V | tail -1)
             if [ "$base" = "$stabile" ] || [ "$piu_alta" = "$stabile" ]; then
-              echo "::error::Il manifest dichiara $base e l'ultima stabile è $stabile, quindi il tag sarebbe v$base-beta.N — che in semver ordina PRIMA di v$stabile e HACS mostrerebbe come più vecchio di quello che l'utente ha già installato. Alza \`version\` in custom_components/omoda9/manifest.json al numero con cui questa modifica uscirà (es. $(echo "$stabile" | awk -F. '{print $1"."$2+1".0"}')), fai commit sul branch della PR e rimetti l'etichetta \`beta\`."
+              echo "::error::Il manifest dichiara $base e l'ultima stabile è $stabile, quindi il tag sarebbe v$base-beta.N — che in semver ordina PRIMA di v$stabile e HACS mostrerebbe come più vecchio di quello che l'utente ha già installato. Alza \`version\` in custom_components/omoda9/manifest.json al numero con cui questa modifica uscirà (es. $(echo "$stabile" | awk -F. '{print $1"."$2+1".0"}')), mergia, e rilancia questo workflow."
               exit 1
             fi
           fi
 
-          # Il contatore è il primo libero fra i TAG (non fra le release: un tag può
-          # esistere senza release). Due PR che puntano alla stessa versione non
-          # collidono; a distinguerle è il titolo della release, non il tag, così il
-          # tag resta semver pulito e HACS lo ordina correttamente.
+          # The counter is the first free one among the TAGS (not among the releases: a tag
+          # can exist without a release). Since every beta now comes from `master`, the
+          # sequence is cumulative by construction: beta.N+1 contains everything beta.N had.
           esistenti=$(gh api "repos/$GITHUB_REPOSITORY/tags?per_page=100" --paginate --jq '.[].name' \
                       | grep -E "^v${base}-beta\.[0-9]+$" || true)
           n=1
@@ -208,40 +152,15 @@ jobs:
           TAG: ${{ steps.ver.outputs.tag }}
           VERSIONE: ${{ steps.ver.outputs.versione }}
           SHA: ${{ steps.pr.outputs.sha }}
-          NUM: ${{ steps.pr.outputs.numero }}
           TITOLO: ${{ steps.pr.outputs.titolo }}
-          URL: ${{ steps.pr.outputs.url }}
         run: |
           set -euo pipefail
 
-          # Le due modalità chiedono al tester due cose diverse, e la differenza va
-          # detta: da una PR si verifica UNA modifica, da master si verifica che le
-          # modifiche entrate finora reggano INSIEME. Chiedere «funziona?» senza dire
-          # quale delle due si sta guardando è come non chiedere niente.
-          if [ -n "$NUM" ]; then
-            intestazione="Build di prova della PR #${NUM} — **${TITOLO}**
-          ${URL}
-
-          Non è una release: è la PR resa installabile, così chi ha l'auto giusta può
-          dire se la macchina fa davvero quello che la PR dichiara."
-            titolo_release="${VERSIONE} — PR #${NUM}: ${TITOLO}"
-          else
-            stabile=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name 2>/dev/null || true)
-            confronto=""
-            if [ -n "$stabile" ] && [ "$stabile" != "null" ]; then
-              confronto="Cosa c'è dentro, rispetto all'ultima stabile:
+          stabile=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name 2>/dev/null || true)
+          confronto=""
+          if [ -n "$stabile" ] && [ "$stabile" != "null" ]; then
+            confronto="Cosa c'è dentro, rispetto all'ultima stabile:
           https://github.com/${GITHUB_REPOSITORY}/compare/${stabile}...master"
-            fi
-            intestazione="Build d'insieme da \`master\` — **${TITOLO}**
-
-          Non è una release, e non è una singola modifica: è tutto quello che è entrato
-          finora, provato **insieme**. È la prova che una beta per-PR non può dare, perché
-          quella verifica una modifica alla volta contro un master di giorni prima. Qui si
-          guardano le cose che nascono dalla combinazione: il numero di entità, i nomi che
-          spariscono in una lingua sola, due sensori che si contendono lo stesso campo.
-
-          ${confronto}"
-            titolo_release="${VERSIONE} — insieme, da master"
           fi
 
           # Le note si scrivono su un FILE, non dentro `$( )`. Un heredoc annidato in una
@@ -249,7 +168,14 @@ jobs:
           # rompe in silenzio quando il testo cambia: `--notes-file` prende lo stesso
           # contenuto senza passare dal parser due volte.
           cat > note-beta.md <<EOF
-          ${intestazione}
+          Build d'insieme da \`master\` — **${TITOLO}**
+
+          Non è una release, e non è una singola modifica: è tutto quello che è entrato
+          finora, provato **insieme**. Si guardano le cose che nascono dalla combinazione:
+          il numero di entità, i nomi che spariscono in una lingua sola, due sensori che si
+          contendono lo stesso campo.
+
+          ${confronto}
 
           **Come si installa.** In HACS, sulla scheda di questa integrazione: menù ⋮ →
           *Redownload* → attiva **Show beta versions** → scegli \`${VERSIONE}\` → riavvia
@@ -260,9 +186,8 @@ jobs:
 
           **Cosa serve sapere dopo.** Non "funziona", ma cosa ha fatto l'auto: il campo di
           stato che è cambiato, e l'ora. \`HTTP 200\` e \`operation.successful\` dicono che
-          il backend ha accettato — non che la vettura abbia eseguito. Scrivilo sulla PR,
-          insieme al modello, alla regione e a cosa NON hai potuto provare: anche quello
-          è un risultato.
+          il backend ha accettato — non che la vettura abbia eseguito. Apri una issue col
+          modello, la regione e cosa NON hai potuto provare: anche quello è un risultato.
 
           Commit: \`${SHA}\`
           EOF
@@ -271,23 +196,5 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --target "$SHA" \
             --prerelease \
-            --title "$titolo_release" \
+            --title "${VERSIONE} — insieme, da master" \
             --notes-file note-beta.md
-
-      - name: Dillo sulla PR
-        # Da master non c'è nessuna PR su cui scriverlo: il link sta nella release, e
-        # chi ha lanciato il workflow lo ha già davanti.
-        if: steps.pr.outputs.numero != ''
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ steps.ver.outputs.tag }}
-          VERSIONE: ${{ steps.ver.outputs.versione }}
-          NUM: ${{ steps.pr.outputs.numero }}
-        run: |
-          set -euo pipefail
-          gh pr comment "$NUM" --repo "$GITHUB_REPOSITORY" --body \
-          "**Beta installabile: \`${VERSIONE}\`** → https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG}
-
-          In HACS: ⋮ → *Redownload* → **Show beta versions** → \`${VERSIONE}\` → riavvia.
-
-          Chi la prova: dì cosa ha fatto **l'auto** — il campo di stato che è cambiato e l'ora — non che il comando è stato accettato. E dì cosa non hai potuto provare."

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -16,6 +16,15 @@ name: Beta
 # telefono — è deliberato, perché chi deve poterla chiedere non sempre ha un
 # computer sotto mano. `workflow_dispatch` resta come uscita di sicurezza.
 #
+# E si avvia anche SENZA una PR: `workflow_dispatch` col campo vuoto taglia la beta
+# da `master`. Serve a collaudare l'INSIEME, che è la cosa che una beta per-PR non
+# può fare: quella prova «master di quando ho aperto il branch, più una modifica»,
+# mai le modifiche una accanto all'altra. E i guasti di questo progetto vivono lì —
+# il conteggio delle entità, le tre liste di traduzione che devono coincidere, le
+# capability: sono proprietà CONGIUNTE, che nessuna singola PR esercita. Il ciclo
+# che serve è: si mergia un lotto, si taglia una beta da master, la si prova su
+# un'auto vera, si passa al lotto dopo.
+#
 # Chi può avviarla: solo chi ha accesso in scrittura, perché è GitHub a decidere
 # chi può etichettare. I tester non avviano niente: ricevono un link e installano.
 
@@ -25,8 +34,8 @@ on:
   workflow_dispatch:
     inputs:
       pr:
-        description: "Numero della PR da cui tagliare la beta"
-        required: true
+        description: "Numero della PR da cui tagliare la beta — vuoto = da master"
+        required: false
         type: string
 
 permissions:
@@ -76,13 +85,29 @@ jobs:
        github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
-      - name: Risolvi la PR e rifiuta i fork
+      - name: Risolvi il bersaglio (una PR, oppure master) e rifiuta i fork
         id: pr
         env:
           GH_TOKEN: ${{ github.token }}
           NUM: ${{ github.event.pull_request.number || inputs.pr }}
         run: |
           set -euo pipefail
+
+          # Campo vuoto = build d'insieme da master. Nessuna PR da risolvere e nessun
+          # fork da rifiutare: `master` è per definizione un branch di questo repo, e ci
+          # si arriva solo passando dalla protezione del branch.
+          if [ -z "${NUM:-}" ]; then
+            sha=$(gh api "repos/$GITHUB_REPOSITORY/commits/master" --jq .sha)
+            {
+              echo "numero="
+              echo "sha=$sha"
+              echo "titolo=tutto quello che è entrato finora"
+              echo "url=https://github.com/$GITHUB_REPOSITORY/commits/master"
+            } >> "$GITHUB_OUTPUT"
+            echo "Build d'insieme da master: $sha"
+            exit 0
+          fi
+
           dati=$(gh pr view "$NUM" --repo "$GITHUB_REPOSITORY" \
                  --json headRefOid,headRepository,headRepositoryOwner,title,url)
           sha=$(echo "$dati"   | jq -r .headRefOid)
@@ -188,12 +213,43 @@ jobs:
           URL: ${{ steps.pr.outputs.url }}
         run: |
           set -euo pipefail
-          note=$(cat <<EOF
-          Build di prova della PR #${NUM} — **${TITOLO}**
+
+          # Le due modalità chiedono al tester due cose diverse, e la differenza va
+          # detta: da una PR si verifica UNA modifica, da master si verifica che le
+          # modifiche entrate finora reggano INSIEME. Chiedere «funziona?» senza dire
+          # quale delle due si sta guardando è come non chiedere niente.
+          if [ -n "$NUM" ]; then
+            intestazione="Build di prova della PR #${NUM} — **${TITOLO}**
           ${URL}
 
           Non è una release: è la PR resa installabile, così chi ha l'auto giusta può
-          dire se la macchina fa davvero quello che la PR dichiara.
+          dire se la macchina fa davvero quello che la PR dichiara."
+            titolo_release="${VERSIONE} — PR #${NUM}: ${TITOLO}"
+          else
+            stabile=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name 2>/dev/null || true)
+            confronto=""
+            if [ -n "$stabile" ] && [ "$stabile" != "null" ]; then
+              confronto="Cosa c'è dentro, rispetto all'ultima stabile:
+          https://github.com/${GITHUB_REPOSITORY}/compare/${stabile}...master"
+            fi
+            intestazione="Build d'insieme da \`master\` — **${TITOLO}**
+
+          Non è una release, e non è una singola modifica: è tutto quello che è entrato
+          finora, provato **insieme**. È la prova che una beta per-PR non può dare, perché
+          quella verifica una modifica alla volta contro un master di giorni prima. Qui si
+          guardano le cose che nascono dalla combinazione: il numero di entità, i nomi che
+          spariscono in una lingua sola, due sensori che si contendono lo stesso campo.
+
+          ${confronto}"
+            titolo_release="${VERSIONE} — insieme, da master"
+          fi
+
+          # Le note si scrivono su un FILE, non dentro `$( )`. Un heredoc annidato in una
+          # sostituzione di comando è il costrutto che qui non serve a niente e che si
+          # rompe in silenzio quando il testo cambia: `--notes-file` prende lo stesso
+          # contenuto senza passare dal parser due volte.
+          cat > note-beta.md <<EOF
+          ${intestazione}
 
           **Come si installa.** In HACS, sulla scheda di questa integrazione: menù ⋮ →
           *Redownload* → attiva **Show beta versions** → scegli \`${VERSIONE}\` → riavvia
@@ -210,15 +266,18 @@ jobs:
 
           Commit: \`${SHA}\`
           EOF
-          )
+
           gh release create "$TAG" omoda9.zip \
             --repo "$GITHUB_REPOSITORY" \
             --target "$SHA" \
             --prerelease \
-            --title "${VERSIONE} — PR #${NUM}: ${TITOLO}" \
-            --notes "$note"
+            --title "$titolo_release" \
+            --notes-file note-beta.md
 
       - name: Dillo sulla PR
+        # Da master non c'è nessuna PR su cui scriverlo: il link sta nella release, e
+        # chi ha lanciato il workflow lo ha già davanti.
+        if: steps.pr.outputs.numero != ''
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.ver.outputs.tag }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,11 +164,24 @@ Land it (small pull request, CI green), it ships to volunteers as a
 affected model has run it. Nothing waits on anybody's free time except the last
 step. Full rules in [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
-A pull request can also be made installable **before** it lands — label it
-`beta` and a pre-release is cut from it. Reach for that whenever the change is
-written for a car you do not own: your instance cannot disprove it, and this is
-what puts it in front of the person whose instance can, while there is still
-time to change it.
+**Pre-releases are cut from `master`, and only from `master`.** A maintainer runs
+`beta.yml`; it builds the head of `master` and publishes `v<version>-beta.N`. The
+sequence is cumulative by construction: beta.N+1 contains everything beta.N had.
+
+This used to work the other way — a `beta` label on a pull request built that branch —
+and it was removed on 5 September 2026 because HACS does not choose the way we assumed.
+It offers the **most recently published** pre-release, not the highest version
+(`hacs/repositories/base.py`, lines 1103-1114 and 385-388: `GET /releases` comes back
+newest-first and is never sorted). So a tester with *Show beta versions* on does not pick
+which build they get, and betas cut from branches make the counter rise while the content
+moves sideways. On 24 August beta.1 to beta.4 came from four different branches; beta.4
+held one pull request and none of the other three.
+
+**What this costs, and it is not yet solved.** There is now no way to put a change in front
+of the person who can disprove it *before* it is merged — which matters most for code
+written for a car nobody here owns, where the author's own instance cannot falsify it.
+If you are writing that kind of change, say so in the pull request and mark it
+`unverified-hardware`; the proof happens after the merge, on the next beta from `master`.
 
 **The version number is not yours to choose.** `manifest.json` carries the number of
 the **next** release, and exactly one pull request ever raises it: the first one opened
@@ -233,17 +246,16 @@ or two. Conflicts are the obvious reason and the least important one. The real
 reason is that **a branch that sits behind loses access to whatever arrived after
 it was cut, and finds out by nothing happening**:
 
-- on 24 August the `beta` label was applied to two pull requests in the same
-  minute. One published a pre-release; the other produced **no workflow run at
-  all and no message**. The workflow had landed on `master` a minute after that
-  branch's last commit;
+- on 24 August, when pre-releases were still cut from branches, the same request was
+  made on two pull requests in the same minute. One published; the other produced **no
+  workflow run at all and no message**, because the workflow had landed on `master` a
+  minute after that branch's last commit — a branch cannot run what it does not have;
 - a stale branch also carries stale CI. A green tick from five days ago says
   nothing about today's `master`, and GitHub may not even have recomputed whether
   the branch still merges.
 
-If you label a pull request and no run appears within a minute, the label did not
-take: push the branch and try again, or use `workflow_dispatch`, which runs from
-the default branch and does not depend on yours.
+A stale branch is also why a green tick proves less than it looks: CI that ran five days
+ago says nothing about today's `master`.
 
 **Save the work**
 
@@ -292,15 +304,17 @@ gh pr edit --add-label unverified-hardware
 **Get it onto a real car, before it lands**
 
 ```bash
-gh pr edit --add-label beta
+gh workflow run beta.yml --repo chery-connect-ha/omoda9-ha
 ```
 
-This publishes a pre-release built from the pull request, installable from HACS
-with *Show beta versions* on. Ask for it whenever the change touches a model
-nobody testing it here owns — including your own author's case, where the change
-is a no-op on your car and therefore unfalsifiable by you. Post the release link
-in the pull request and name who you are asking. Only write access can label, so
-a tester never has to run anything: they get a link.
+This publishes a pre-release built from the head of `master`, installable from HACS with
+*Show beta versions* on — everything merged so far, tried **together**. That is the check
+no single pull request can perform: the entity count, the three translation lists that must
+agree, two sensors contending for one field are all JOINT properties.
+
+Run it after merging a batch, then post the release link where the people with the relevant
+cars will see it and name who you are asking, saying which models the batch touched. Only
+write access can run a workflow, so a tester never has to run anything: they get a link.
 
 A beta is never cut from a fork. If this pull request comes from one, a member
 publishes it by hand after reading what is in it.
@@ -335,7 +349,7 @@ reads as disagreement.
 
 **Cutting a release** (maintainers)
 
-A pre-release from a pull request is the `beta` label — do not do it by hand.
+A pre-release is `gh workflow run beta.yml`, from `master` — do not do it by hand.
 
 For a **stable**, the archive is not optional. `hacs.json` sets `zip_release`
 with `omoda9.zip`, so HACS installs *only* from a release carrying that asset:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,8 @@ Adding a car should mean adding rows, not adding code paths.
 **How a change moves.** It **lands** — cheaply if it only touches your own car's
 data, with one read by somebody else if it touches shared code, and labelled
 `unverified-hardware` if it is written for a car none of us owns. It **ships as a
-pre-release** — on merge, or from the pull request itself if you label it `beta`
-— so you have your own work on your own car the same day. It becomes
+pre-release** cut from `master` after the merge, so you have your own work on your own
+car the same day. It becomes
 **stable** only once someone who owns each affected model has run it. Merging is
 never blocked. Only the last step is.
 
@@ -123,12 +123,19 @@ versions* for this repository in HACS and has them on their own car the same day
 This is deliberate: nobody in this project should ever be separated from work they
 just did because they are waiting on somebody else's free time.
 
-**And it can ship before it lands.** Put the label `beta` on a pull request and a
-pre-release is built from it, installable the same way. That is what carries a
-change to the one person who can disprove it *while there is still time to change
-it* — which matters most exactly where the author is powerless: code written for a
-car they do not own is, on their own car, a no-op. It is two taps in a phone
-browser, and only write access can do it, so a tester never runs anything.
+**Every pre-release comes from `master`, and contains everything merged so far.** A
+maintainer runs the `Beta` workflow after a batch lands. It is deliberately not built from
+individual branches: HACS offers whoever has *Show beta versions* on the **last pre-release
+published**, not the highest version, so builds cut from separate branches would hand
+testers a rising number with sideways content. On 24 August that is exactly what happened,
+and it is why the mechanism changed.
+
+**What we lost with it, honestly.** There is no longer a way to try a change *before* it is
+merged. That mattered most for code written for a car its author does not own — on their own
+instance it is a no-op, so they cannot disprove it. For now such changes land marked
+`unverified-hardware` and are proven on the next beta from `master`. If you can think of a
+shape that restores the pre-merge test without publishing an incoherent pre-release, say so:
+it is an open problem, not a settled trade.
 
 ### 3. It becomes stable
 


### PR DESCRIPTION
Closes #42.

## What changes

`workflow_dispatch`'s `pr` input becomes optional. Leave it empty and the beta is cut from `master`.

- **empty** → resolve `master`'s head, skip the fork check, and publish notes that ask the tester about the aggregate, with a compare link against the last stable so they can see what is in it. Release title: `1.14.0-beta.N — insieme, da master`.
- **a number** → byte for byte what happens today.

The version guard needed nothing: it already refuses a beta whose manifest version is not ahead of the latest stable, and on `master` that is satisfied by whichever release-bearing pull request merged last.

## The bug I hit on the way, which is worth more than the feature

The release notes were built with a heredoc nested inside a command substitution — `note=$(cat <<EOF … EOF)`. It works until the text changes. When I shortened the first paragraph, `bash -n` started reporting an unterminated quote forty lines further down: it had stopped recognising the heredoc, so it was parsing the body as code and hit the apostrophe in `l'ora`. Nothing in the construct was load-bearing, so the notes now go to a file and the release is created with `--notes-file`.

Recording it because the failure mode is nasty: the syntax error appears in a line nobody touched, and it depends on how many lines of prose sit above it.

## How it was checked, since the workflow itself cannot be run from a branch

- every `run:` block in the file extracted and passed through `bash -n` — the whole file, not just the parts I edited, which is how the heredoc was caught at all;
- the publish step run for real with `gh` stubbed out, in both modes, to read the notes and the release title each one produces. The pull-request mode output is unchanged.

What that does **not** cover: the actual workflow run, the `gh api` calls, and whether the zip is built correctly from a `master` checkout. The first real integration build will be the first proof of those, and it should be cut deliberately with somebody ready to install it.

## Why this is worth doing now rather than after the queue drains

Rino is away from early September (#10). Anything that needs a real car has a short window, and the first field test of the aggregate should not land after the car is gone. It is one optional input.

## A note on language

The file is in Italian and I kept it that way, including the new blocks. `AGENTS.md` in #40 says new code is English and that a block you are editing becomes English as part of the change — but #40 has not merged, and half-converting this one file would leave two languages inside a single `run:` block, which reads worse than either. When #40 lands, this workflow is a good candidate for a conversion of its own.

---

*Per the convention: the analysis of the gap, the `bash -n` sweep and the stubbed dry-run were carried out by the agent I drive. The decision that the aggregate needs to be testable, and that it needs to be testable this week, is mine.*
