### PR TITLE
docs+ci: one pull request raises the version, and a check that says so

### DIFF
--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -1,0 +1,71 @@
+name: Version guard
+
+# Exactly one pull request raises `manifest.json`: the first one opened after a stable
+# ships. Everybody else adds their entry to the section already open and leaves the
+# version alone. The rule lives in AGENTS.md; this workflow is the thing that holds it
+# up, because a rule without one is a hope (AGENTS.md, "Before you write a rule").
+#
+# Why it exists, in one line: on 25 August 2026 three branches each declared `1.14.0`
+# and each opened their own changelog section. The first merged; the other two went
+# from mergeable to conflicting in the same minute, and two more were carrying the same
+# collision behind them. Five pull requests, one line, three authors.
+#
+# This file is in English, unlike its neighbours, and deliberately: the message below is
+# read by whoever trips over it, and not all of us read Italian.
+#
+# What it does NOT do: judge whether the number chosen is the right one. When the version
+# is due to be raised — that is, when the manifest is still sitting on the last stable —
+# any number passes, because which one it should be is a release decision, not a
+# workflow's.
+
+on:
+  pull_request:
+    paths:
+      - "custom_components/omoda9/manifest.json"
+
+permissions:
+  contents: read
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Only one pull request raises the version
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          MANIFEST=custom_components/omoda9/manifest.json
+
+          new=$(jq -r .version "$MANIFEST")
+          base=$(git show "$BASE:$MANIFEST" | jq -r .version)
+
+          if [ "$new" = "$base" ]; then
+            echo "Version unchanged ($base): nothing to check."
+            exit 0
+          fi
+
+          # The version DID change. That is legitimate only if the number had not been
+          # raised yet since the last stable — that is, if the base manifest was still
+          # sitting on it. `releases/latest` excludes pre-releases, which is what we
+          # want here: a beta does not open a version, it accompanies one.
+          stable=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name 2>/dev/null | sed 's/^v//' || true)
+
+          if [ -z "$stable" ] || [ "$stable" = "null" ]; then
+            echo "No stable release published yet: the first number is chosen here."
+            exit 0
+          fi
+
+          if [ "$base" = "$stable" ]; then
+            echo "The manifest was still on the last stable ($stable) and this pull request opens $new."
+            echo "It is the first one after the release, so raising it is its job."
+            exit 0
+          fi
+
+          echo "::error file=$MANIFEST::The next release already has its number: $base, opened by the first pull request after stable $stable. This one changes it to $new, and whoever merges second inherits a conflict on a single line. Put \"version\": \"$base\" back in the manifest and add your entry to the ## v$base section already in CHANGELOG.md. If this really has to ship as a release of its own, say so on the pull request — that is a release decision, not this check's. The rule is in AGENTS.md, 'The version number is not yours to choose'." >&2
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,6 +170,33 @@ written for a car you do not own: your instance cannot disprove it, and this is
 what puts it in front of the person whose instance can, while there is still
 time to change it.
 
+**The version number is not yours to choose.** `manifest.json` carries the number of
+the **next** release, and exactly one pull request ever raises it: the first one opened
+after a stable ships. Everybody else adds their entry to the existing `## v<next>`
+section of `CHANGELOG.md` and leaves `manifest.json` alone.
+
+Bumping per pull request looks harmless and is not. On 25 August 2026 three branches
+each set `1.14.0` and each opened their own `## v1.14.0` section. The first merged; the
+other two went from mergeable to conflicting in the same minute, and two more were
+carrying the same collision behind them. Five pull requests, one line, three authors,
+every one of whom had to be asked to redo work that was already correct. It is also a
+question you cannot answer alone: whether your change is a patch or a minor depends on
+what ships beside it, which you do not know when you open the branch.
+
+This does **not** make `CHANGELOG.md` uncontended — everyone still writes into the same
+section. But that is an ordinary additive conflict instead of one line carrying three
+different values.
+
+⚠️ **The one time you do raise it.** After a stable ships, the next pull request must,
+or no beta can be cut from anything: `beta.yml` refuses to build a pre-release whose
+manifest is not ahead of the latest stable, because in semver `v1.13.0-beta.1` sorts
+*before* `v1.13.0` and HACS would offer it as a downgrade. The workflow fails loudly and
+names the number to use — but doing it on purpose beats being told off by CI.
+
+*What enforces it:* `.github/workflows/version-guard.yml` fails a pull request that
+changes the version while the next number is already set. Per the section above, this
+rule ships with the thing that holds it up rather than with a request to remember it.
+
 ## The commands
 
 `master` is protected: no direct pushes. Everything below assumes the remote is


### PR DESCRIPTION
Closes #44.

Two files: the rule in `AGENTS.md`, and the check that holds it up.

## The rule

> `manifest.json` carries the number of the **next** release, and exactly one pull request ever raises it: the first one opened after a stable ships. Everybody else adds their entry to the existing `## v<next>` section and leaves the version alone.

Today that number is `1.14.0`, taken by #32. So #14, #19, #25 and #26 fold into it and drop their second bump.

**What it fixes:** `manifest.json` stops being a contended file — one bump per release instead of one per pull request. That was one of the two files that made five parallel branches expensive this week.

**What it does not fix, and the text says so:** `CHANGELOG.md` stays shared. Everyone writes into the same section and those edits still collide — but as an ordinary additive conflict, not one line carrying three different values.

## The check

`AGENTS.md` says a rule without something enforcing it is a hope, so this one arrives with `version-guard.yml`. On a pull request touching the manifest it compares the new version against the base, and:

| situation | result |
|---|---|
| version unchanged | passes, silently |
| base was still on the last stable | passes — this is the legitimate first bump |
| the next number is already set | **fails**, naming the number to restore and the section to write into |
| no stable released yet | passes |

It deliberately does **not** judge which number was chosen. When a bump is due, any number passes: which one it should be is a release decision, not a workflow's.

Verified against all four cases with the `git` and `gh` calls stubbed, since the workflow cannot be run from a branch. What that does not cover is the real `gh api` call and the `paths:` trigger — the first pull request that touches the manifest will be the proof of those, and given the rule, that is #14.

## Two choices worth flagging

**This file is in English while `beta.yml` and its neighbours are Italian.** Deliberate: the error message is read by whoever trips over it, and not all of us read Italian. #45 proposes making that general; this file does not wait for it.

**On the wider practice**, so the rule reads as an adaptation rather than an invention: most mature Home Assistant custom integrations bump at release time, either in a dedicated release pull request or by keeping a placeholder in the manifest and injecting the number from the tag at build time. Per-pull-request bumping is uncommon and generally considered a mistake. We cannot take the placeholder form as-is, because `beta.yml`'s guard needs a real number ahead of the stable before any beta can be cut — a constraint we chose on purpose and documented at length. Hence one bump per release, as everyone else does, only early enough for our own pipeline. Worth knowing that `beta.yml` already injects the version into the zip, so half the machinery for the canonical form exists; moving the rest is coherent and is **not** proposed here.

---

*Per the convention: the collision was measured by the agent I drive across the open pull requests, and it wrote and exercised the guard. Deciding that this needed a rule rather than four separate answers is mine.*
