### PR TITLE
tools+docs: four probes, and what they say about the bundled certificate

### DIFF
--- a/docs/enrollment-findings.md
+++ b/docs/enrollment-findings.md
@@ -1,0 +1,270 @@
+# Does the MQTT stack support a per-device enrollment?
+
+**Measured on 2026-08-25**, against the EU region
+(`tspemqx-app-eu.cheryinternational.com`), with the probes in
+[`tools/enrollment_probe/`](../tools/enrollment_probe/). Every number below can be
+re-produced by re-running them; where a step could not be run, it says so instead
+of guessing.
+
+## Why this was asked
+
+`custom_components/omoda9/certs/store.json` carries mutual-TLS material — `ca.pem`,
+`client.pem`, `client.key` — for 40 regional brokers. It comes from the public
+assets of the official APK, and it is the same for every user of a region. That
+means this repository redistributes a **vendor private key**. The goal is to stop
+doing that.
+
+The hypothesis worth falsifying was that this material is only *bootstrap*: that
+somewhere in the `getTuserId → loginTSP` chain the app trades it for a per-device
+identity — a locally generated key plus a CSR, or a dynamic registration. If such
+an enrollment exists, every user can obtain their own material and the bundle can
+go without losing anything.
+
+## Verdict
+
+**The enrollment does not exist, and the certificate cannot simply be dropped
+either.** Both halves matter, and the second one contradicts the outcome the
+investigation was hoping for:
+
+* the bundled certificate is a per-region constant, not a per-device identity
+  (step 1);
+* the broker **does** require a client certificate, and it checks who signed it: a
+  self-signed certificate generated locally is refused (step 2);
+* nothing in the provisioning responses looks like credential material — no
+  certificate, no CSR, no `productKey`/`deviceName`/`deviceSecret` (step 3);
+* nothing anywhere generates a key pair or a CSR (step 4).
+
+So the bundle cannot be removed without a replacement, and there is no
+replacement to be had from the vendor. What remains is a distribution question,
+not a protocol one — see [What is actually left](#what-is-actually-left).
+
+## Step 1 — what the certificate actually is
+
+`python3 tools/enrollment_probe/step1_cert_inspect.py`
+
+40 regions, all 40 parsed, all 40 with a private key that matches its certificate.
+
+| property | value |
+|---|---|
+| subject | `CN=client, O=EMQX, L=ShangHai, ST=SH, C=CN` — **identical in all 40 regions** |
+| SAN | absent in all 40 |
+| key usage / extended key usage | absent in all 40 |
+| non-standard extensions | none in all 40 |
+| public key | RSA-2048, `sha256WithRSAEncryption` |
+| validity | 3650 days (10 years) in all 40, issued between 2023 and 2026 |
+| distinct serials | 40 |
+| distinct public keys | 40 |
+| distinct issuing CAs | 40 |
+| per-device markers in CN/SAN | none |
+
+The EU certificate this integration uses:
+
+```
+subject     CN=client,O=EMQX,L=ShangHai,ST=SH,C=CN
+issuer      CN=tspemqx-app-eu.cheryinternational.com,OU=EMQX,O=EMQX,L=ShangHai,ST=SH,C=CN
+            (emailAddress=…@mychery.com)
+serial      1c7a383f7ac05df7278cd5d16d504bfa88ab7f8b
+validity    2023-10-26 .. 2033-10-23   (3650 days)
+```
+
+Read against the criteria set for this step: the CN is the generic literal
+`client`, there is no SAN at all, and the validity is a decade. Different serials
+and different keys across regions, with an identical subject structure and an
+issuer that is the region's own self-signed CA, means **one identity per region**
+— not one per device, and not one per account. Nothing in the certificate carries
+a device id, a VIN or a `tUserId`.
+
+This confirms what `cert_bundle.py` already documents. It does not by itself say
+whether the certificate is *needed*.
+
+## Step 2 — does the broker require it?
+
+`python3 tools/enrollment_probe/step2_tls_probe.py --repeat 3`
+
+Three variants per port — no client certificate, the bundled one, and a
+throw-away self-signed one generated on the spot — three attempts each,
+consistent across all three.
+
+| port | no certificate | bundled certificate | self-signed certificate |
+|---|---|---|---|
+| 8083 (the port the integration dials) | handshake OK, **server closes immediately** | handshake OK, **connection held open** | handshake OK, **server closes immediately** |
+| 8883 | TCP timeout | — | — |
+| 8884 | TCP timeout | — | — |
+| 1883 | TCP timeout | — | — |
+| 443 | a different service answers (see below) | — | — |
+
+**The trap this step was designed to avoid.** Under TLS 1.3 the handshake
+completes on the client side before the server has judged the certificate it did
+or did not receive. Reading only "handshake_ok" on port 8083 would have produced
+exactly the conclusion the decision table's first row describes — *remove the
+bundle, no replacement needed* — and it would have been wrong. What separates
+acceptance from rejection is what happens next, and the probe waits for it: with
+the bundled certificate the listener holds the connection open waiting for an MQTT
+CONNECT; without one, and with a self-signed one, it sends a clean EOF within
+milliseconds. That is EMQX with `verify_peer` and `fail_if_no_peer_cert`. The
+alert 116 `certificate_required` this step went looking for never appears — the
+server does not bother to send it — so its absence is not evidence of anything.
+
+**The self-signed variant is the important one.** The broker does not merely want
+*a* certificate; it wants one that chains to the region CA. A user cannot generate
+accepted material locally.
+
+**Which stack this is.** The certificate served on 8083 is
+`CN=CA, O=EMQX, …`, issued by the region's own CA, with the broker hostname in its
+SAN. It is a self-hosted EMQX. It is **not** Aliyun IoT Platform — nothing
+resembling `*.iot-as-mqtt.<region>.aliyuncs.com` appears. This falsifies the
+priority hypothesis of this investigation: there is no Aliyun dynamic
+registration here, because there is no Aliyun.
+
+Port 443 on the same address answers with a certificate for
+`tspterminal-eu.cheryinternational.com`, issued by `Chery CA` — a different
+service sharing the address. It accepts connections without a client certificate,
+which says nothing whatsoever about the broker's policy. The probe labels it as
+such rather than counting it as a result.
+
+## Step 3 — is credential material in the provisioning responses?
+
+`python3 tools/enrollment_probe/step3_response_scan.py`
+
+The session was reused as required: existing token, no refresh, no OTP. The stored
+access token was 23 648 s into its 43 200 s lifetime and the BFF login succeeded,
+so this step ran in full.
+
+Three read-only responses were captured and scanned recursively for base64 DER
+(`MII…`), base64 PEM (`LS0tLS1CRUdJTi`), literal PEM headers, strings longer than
+200 characters, and the marker key names.
+
+| endpoint | HTTP | code | distinct keys | hits |
+|---|---|---|---|---|
+| `auth/login` | 200 | 0 | 9 | 1 — `$.data.userToken`, a 217-character opaque string |
+| `auth/getTuserId` | 200 | 0 | 8 | none |
+| `vmc/queryList` | 200 | 0 | 39 | none |
+
+The single hit is the session token the integration already uses; it is long, not
+cryptographic material, and its value is redacted in the probe's output.
+
+Because an absence is only a finding if you can show what was there instead, the
+probe enumerates every key name it saw. `queryList` — by far the richest response
+— returns:
+
+```
+airConditionerType, authorizeEndTime, authorizeStartTime, authorizeTime,
+authorizeType, carNumber, carPicture, code, colorCode, colorName, colorNameEn,
+data, defCar, engineNumber, fullName, hiValue, iccid, isHaveLoAndHi, key,
+loValue, maxAirDuration, maxEngineDuration, maxTemperature, minTemperature, msg,
+nickname, ok, passwordType, powerType, promotionalCardUrl, remarks,
+skylightType, steeringWheelPosition, tboxSn, temperatureStepLength, txId,
+typeCode, vehicleType, vin
+```
+
+None of `cert`, `pem`, `csr`, `p12`, `keystore`, `productKey`, `deviceName`,
+`deviceSecret`, `iotId`, `clientId`, `mqttUsername`, `mqttPassword` appears in any
+of the three responses. `iccid` and `tboxSn` are device *identifiers*, not
+credentials, and are returned alongside the paint colour and the sunroof type.
+
+**`loginTSP` could not be executed, and this is a result, not a gap.** The brief
+assumed the `getTuserId → loginTSP` chain was implemented in `core/provision.py`.
+It is not: the module implements `getTuserId → queryList`, and its own docstring
+records that the app's `getTspToken()`/`loginTSP` is a **native** call, a no-op in
+the DEX. There is no request to replay and no observed traffic to imitate, so
+there was nothing to run. Guessing endpoint names was ruled out: an invented
+result would be worse than a missing one. `README.md` already states the same
+thing — the car_token chain exists only in the experimental module and is unused
+at runtime.
+
+## Step 4 — does anything generate a key pair?
+
+`python3 tools/enrollment_probe/step4_keygen_scan.py --extra ../.coding_agent --extra ../security-disclosure`
+
+166 text files across the repository, the agent's working notes and the security
+disclosure material.
+
+| pattern | hits |
+|---|---|
+| `KeyPairGenerator` / `generateKeyPair` | 0 |
+| PKCS#10 / `CertificateSigningRequest` / CSR | 0 |
+| Bouncy Castle / Spongy Castle / BKS | 0 |
+| keystore construction / keytool / `.jks` / `.p12` | 1 — false positive |
+| `generate_private_key` / `CertificateBuilder` | 0 |
+| `openssl req` / `genrsa` / `genpkey` | 0 |
+| enrollment / dynamic registration vocabulary | 0 |
+
+The single match is `tests/test_repo_hygiene.py:47`, the list of file extensions
+the repository refuses to track — `".key", ".pem", ".cer", ".p12", ".pfx"`. It is
+a guard against committing key material, not code that produces any.
+
+The probe skips its own directory and this report. `step2_tls_probe.py` genuinely
+does generate a key pair for its self-signed variant, and this file names every
+pattern in the table while reporting that none was found: counting either would be
+manufacturing the evidence. The effect is not hypothetical — run against a tree
+containing this report, the scan returns fourteen matches, all of them these
+paragraphs.
+
+**Nothing generates a key pair.** A CSR-based enrollment therefore cannot exist in
+this codebase, and none was ever observed in the app.
+
+## Conclusion against the decision table
+
+| criterion | result |
+|---|---|
+| Handshake without a certificate succeeds (step 2) → *remove the bundle, no replacement* | **No.** The handshake completes but the broker drops the connection. The certificate is required. |
+| `productKey`/`deviceSecret`/CSR in the responses (step 3) → *implement enrollment* | **No.** Nothing of the kind in any of the three responses. |
+| No client-side key pair and no endpoint (steps 3–4) → *enrollment does not exist: BYO or drop the MQTT path* | **Yes.** This is the row that applies. |
+
+With one correction to what that third row implies. "BYO" cannot mean *the user
+generates their own key*: step 2 shows the broker rejects material it did not
+sign. It can only mean *the user supplies the same vendor material themselves*,
+extracting it from the APK asset on a device they own.
+
+## What is actually left
+
+Three options, and none of them is free:
+
+1. **Keep the bundle.** Function is preserved; the vendor private key stays
+   redistributed in a public repository. This is the status quo.
+2. **Ship the code, not the material.** Keep the de-obfuscation in
+   `cert_bundle.py`, drop `store.json`, and have the user point the integration at
+   the asset from their own copy of the APK. Nothing is lost functionally; the
+   setup gains a manual step, and the repository stops carrying the key.
+3. **Drop the MQTT path.** Push telemetry goes away and everything falls back to
+   REST polling. This is a real loss of function, for a real simplification.
+
+Option 2 is the only one that resolves the original problem without giving
+anything up, and it is a change to the config flow and the packaging — not to the
+protocol. Choosing between them is out of scope here.
+
+## What this does and does not change about safety
+
+The certificate admits a client to the transport and nothing more. Account
+isolation is elsewhere and was already documented: the MQTT username is the
+`tUserId`, the password is `md5(tUserId + seed)`, and the topic ACL is
+`app/<channel>/<tUserId>/…` (`coordinator.py:721-731`). Holding the shared
+certificate does not let anyone read another account's messages.
+
+So removing the bundle is about **not redistributing someone else's private key**
+— a licensing and key-hygiene problem, and the vendor's exposure — not about
+protecting users of this integration from each other. Worth being precise about,
+because the two arguments justify different levels of urgency.
+
+## An observation outside this scope
+
+`coordinator.py:735` calls `tls_insecure_set(True)`, with the comment that the
+broker presents a non-matching CN. Measured today, that is no longer true: a
+handshake with full verification — the bundled `ca.pem` as trust anchor,
+`check_hostname` on, `CERT_REQUIRED` — succeeds against port 8083 and the
+connection is held open. The server certificate's CN is indeed `CA`, but its SAN
+carries the broker hostname, which is what a modern TLS stack checks.
+
+Recorded here because it was measured here. It is a separate change, with its own
+field test, and it is not part of this work.
+
+## Limits of this report
+
+* One region was probed on the network: the EU broker this account uses. Step 1
+  covers all 40; steps 2 and 3 speak for the EU region only.
+* Ports 8883, 8884 and 1883 timed out at TCP level. Timeout is not a closed port:
+  a firewall on the path would look the same. No conclusion is drawn from them.
+* Step 3 saw the responses this account receives. A different `authorizeType`, a
+  different region or a vehicle with different options could return more fields.
+* No command, no `taskId`, no PIN and no OTP were used at any point, by design.
+  Anything only observable while sending a command was therefore not observed.

--- a/tools/enrollment_probe/README.md
+++ b/tools/enrollment_probe/README.md
@@ -1,0 +1,59 @@
+# enrollment probe
+
+Four standalone probes that answer one question: **can each user of this
+integration obtain their own MQTT credentials, instead of sharing the vendor
+certificate bundled in `custom_components/omoda9/certs/store.json`?**
+
+They exist to be re-run and disagreed with. Every claim in
+[`docs/enrollment-findings.md`](../../docs/enrollment-findings.md) comes from one
+of them.
+
+They live outside `custom_components/` on purpose: the HACS payload is built from
+that directory alone, so nothing here ships to users.
+
+| script | question | network |
+|---|---|---|
+| `step1_cert_inspect.py` | Is the bundled certificate a per-device identity or a per-region constant? | none |
+| `step2_tls_probe.py` | Does the broker actually demand a client certificate, and does it check who signed it? | TLS handshake only |
+| `step3_response_scan.py` | Do the provisioning responses carry per-device credential material? | read-only BFF calls |
+| `step4_keygen_scan.py` | Does anything, anywhere, generate a key pair or a CSR? | none |
+
+## Safety rules these scripts obey
+
+* **Nothing reaches the car.** No `setVecDefault`, no `checkPassword`, no PIN, no
+  `taskId`, no `/asc/vehicleControl/*`. A wrong PIN increments a counter on Chery's
+  side and can lock the account, so the PIN is never used at all.
+* **No OTP.** `step3` reuses the stored session and, by default, does not even
+  refresh it: it works on a copy of the token file so a running Home Assistant
+  never has its refresh token rotated underneath it. An expired token stops the
+  probe; it never asks for a new code.
+* **No MQTT authentication.** `step2` stops at the end of the TLS handshake and
+  then waits passively. It never sends a CONNECT.
+* **No secrets in the output.** VIN, tokens, e-mail, phone number and coordinates
+  are redacted. Values are reported by shape — type, length, an eight-character
+  prefix — and even the prefix is suppressed for anything carrying an account
+  identifier.
+* **Nothing is written to the repository.** The certificate bundle is
+  de-obfuscated in memory. When OpenSSL requires a key on disk, it goes to a
+  private temporary directory, is overwritten with zeros and removed.
+
+## Running them
+
+```bash
+python3 tools/enrollment_probe/step1_cert_inspect.py
+python3 tools/enrollment_probe/step2_tls_probe.py --repeat 3
+python3 tools/enrollment_probe/step4_keygen_scan.py --extra ../.coding_agent
+```
+
+`step3` needs a configured account. It reads the same environment variables
+`core/provision.py` already uses:
+
+```bash
+export VIN=...                 # your vehicle
+export OMODA_TOKEN_PATH=...    # <config>/omoda9_<VIN>_token.json
+python3 tools/enrollment_probe/step3_response_scan.py
+```
+
+Every script takes `--json` for machine-readable output. The only dependency
+beyond the standard library is `cryptography`, which the integration already
+requires; `step3` also uses `requests`, for the same reason.

--- a/tools/enrollment_probe/step1_cert_inspect.py
+++ b/tools/enrollment_probe/step1_cert_inspect.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Step 1 — offline X.509 inspection of the bundled mutual-TLS material.
+
+The question this step answers: is the client certificate shipped in
+`custom_components/omoda9/certs/store.json` a *per-device* identity, or a
+constant shared by every user of a region?
+
+Reading key (from the investigation brief):
+
+  * generic CN/SAN (app name, region, `client`)  -> not a per-device identity;
+  * CN/SAN carrying a device id, VIN or tUserId  -> an enrollment exists;
+  * multi-year validity                          -> static material;
+  * different serials but identical CN structure -> one identity per region.
+
+Nothing is written to disk: the bundle is de-obfuscated in memory and only
+metadata is printed. Private key bytes never leave this process.
+
+Usage:
+    python3 tools/enrollment_probe/step1_cert_inspect.py [--json] [--store PATH]
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+import sys
+from datetime import timezone
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+PACKAGE = os.path.join(REPO, "custom_components", "omoda9")
+
+# Extensions we consider "standard furniture" for a TLS client certificate.
+# Anything outside this set is reported verbatim: a vendor-specific OID carrying
+# a device identifier is exactly the kind of thing that would prove enrollment.
+WELL_KNOWN_OIDS = {
+    "2.5.29.14",  # subjectKeyIdentifier
+    "2.5.29.15",  # keyUsage
+    "2.5.29.17",  # subjectAltName
+    "2.5.29.19",  # basicConstraints
+    "2.5.29.31",  # cRLDistributionPoints
+    "2.5.29.32",  # certificatePolicies
+    "2.5.29.35",  # authorityKeyIdentifier
+    "2.5.29.37",  # extendedKeyUsage
+    "1.3.6.1.5.5.7.1.1",  # authorityInfoAccess
+}
+
+
+def load_cert_bundle():
+    """Import `cert_bundle.py` by path, without importing the HA package."""
+    path = os.path.join(PACKAGE, "cert_bundle.py")
+    spec = importlib.util.spec_from_file_location("_cert_bundle", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def key_usage(cert: x509.Certificate) -> list[str]:
+    try:
+        ku = cert.extensions.get_extension_for_class(x509.KeyUsage).value
+    except x509.ExtensionNotFound:
+        return []
+    names = [
+        "digital_signature", "content_commitment", "key_encipherment",
+        "data_encipherment", "key_agreement", "key_cert_sign", "crl_sign",
+    ]
+    out = [n for n in names if getattr(ku, n, False)]
+    if ku.key_agreement:  # encipher/decipher_only only defined when key_agreement is set
+        for n in ("encipher_only", "decipher_only"):
+            if getattr(ku, n, False):
+                out.append(n)
+    return out
+
+
+def extended_key_usage(cert: x509.Certificate) -> list[str]:
+    try:
+        eku = cert.extensions.get_extension_for_class(x509.ExtendedKeyUsage).value
+    except x509.ExtensionNotFound:
+        return []
+    return [getattr(oid, "_name", None) or oid.dotted_string for oid in eku]
+
+
+def subject_alt_names(cert: x509.Certificate) -> list[str]:
+    try:
+        san = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+    except x509.ExtensionNotFound:
+        return []
+    out = []
+    for name in san:
+        out.append(f"{type(name).__name__}:{getattr(name, 'value', name)}")
+    return out
+
+
+def unusual_extensions(cert: x509.Certificate) -> list[str]:
+    out = []
+    for ext in cert.extensions:
+        dotted = ext.oid.dotted_string
+        if dotted in WELL_KNOWN_OIDS:
+            continue
+        label = getattr(ext.oid, "_name", None) or "unknown"
+        out.append(f"{dotted} ({label})")
+    return out
+
+
+def public_key_info(cert: x509.Certificate) -> tuple[str, str]:
+    """(description, SHA-256 fingerprint of the SubjectPublicKeyInfo).
+
+    The SPKI digest is a hash of *public* material and is the cheapest way to say
+    whether two regions ship the same identity or two different ones.
+    """
+    pub = cert.public_key()
+    if isinstance(pub, rsa.RSAPublicKey):
+        desc = f"RSA-{pub.key_size}"
+    elif isinstance(pub, ec.EllipticCurvePublicKey):
+        desc = f"EC-{pub.curve.name}"
+    else:
+        desc = type(pub).__name__
+    spki = pub.public_bytes(serialization.Encoding.DER,
+                            serialization.PublicFormat.SubjectPublicKeyInfo)
+    return desc, hashlib.sha256(spki).hexdigest()
+
+
+def key_matches_cert(key_pem: bytes, cert: x509.Certificate) -> bool | None:
+    """True if `client.key` is the private half of `client.pem`'s public key."""
+    try:
+        key = serialization.load_pem_private_key(key_pem, password=None)
+    except Exception:
+        return None
+    a = key.public_key().public_bytes(serialization.Encoding.DER,
+                                      serialization.PublicFormat.SubjectPublicKeyInfo)
+    b = cert.public_key().public_bytes(serialization.Encoding.DER,
+                                       serialization.PublicFormat.SubjectPublicKeyInfo)
+    return a == b
+
+
+def looks_per_device(cert: x509.Certificate) -> list[str]:
+    """Heuristic flags for identifiers that would only exist per device."""
+    haystack = [cert.subject.rfc4514_string(), *subject_alt_names(cert)]
+    flags = []
+    for text in haystack:
+        for token in text.replace("=", " ").replace(",", " ").replace(":", " ").split():
+            if len(token) == 17 and token.isalnum() and any(c.isdigit() for c in token):
+                flags.append(f"VIN-shaped token ({len(token)} chars)")
+            elif len(token) >= 24 and token.isalnum():
+                flags.append(f"opaque id-shaped token ({len(token)} chars)")
+    return sorted(set(flags))
+
+
+def inspect_region(host: str, blobs: dict[str, bytes]) -> dict:
+    cert = x509.load_pem_x509_certificate(blobs["client.pem"])
+    ca = x509.load_pem_x509_certificate(blobs["ca.pem"])
+    not_before = cert.not_valid_before_utc.replace(tzinfo=timezone.utc)
+    not_after = cert.not_valid_after_utc.replace(tzinfo=timezone.utc)
+    key_desc, spki = public_key_info(cert)
+    return {
+        "host": host,
+        "subject": cert.subject.rfc4514_string(),
+        "subject_cn": next((a.value for a in cert.subject
+                            if a.oid == x509.NameOID.COMMON_NAME), None),
+        "san": subject_alt_names(cert),
+        "issuer": cert.issuer.rfc4514_string(),
+        "issuer_cn": next((a.value for a in cert.issuer
+                           if a.oid == x509.NameOID.COMMON_NAME), None),
+        "serial_hex": format(cert.serial_number, "x"),
+        "not_before": not_before.isoformat(),
+        "not_after": not_after.isoformat(),
+        "validity_days": (not_after - not_before).days,
+        "signature_algorithm": cert.signature_algorithm_oid._name,
+        "public_key": key_desc,
+        "spki_sha256": spki,
+        "key_usage": key_usage(cert),
+        "extended_key_usage": extended_key_usage(cert),
+        "unusual_extensions": unusual_extensions(cert),
+        "per_device_markers": looks_per_device(cert),
+        "key_matches_cert": key_matches_cert(blobs["client.key"], cert),
+        "ca_subject": ca.subject.rfc4514_string(),
+        "ca_fingerprint_sha256": ca.fingerprint(hashes.SHA256()).hex(),
+        "cert_fingerprint_sha256": cert.fingerprint(hashes.SHA256()).hex(),
+    }
+
+
+def summarise(rows: list[dict]) -> dict:
+    def distinct(field):
+        return sorted({json.dumps(r[field], sort_keys=True) for r in rows})
+
+    return {
+        "regions": len(rows),
+        "distinct_subjects": len(distinct("subject")),
+        "distinct_serials": len(distinct("serial_hex")),
+        "distinct_spki": len(distinct("spki_sha256")),
+        "distinct_issuers": len(distinct("issuer")),
+        "distinct_ca_fingerprints": len(distinct("ca_fingerprint_sha256")),
+        "subjects": [json.loads(s) for s in distinct("subject")],
+        "issuers": [json.loads(s) for s in distinct("issuer")],
+        "validity_days_min": min(r["validity_days"] for r in rows),
+        "validity_days_max": max(r["validity_days"] for r in rows),
+        "regions_with_per_device_markers": [r["host"] for r in rows
+                                            if r["per_device_markers"]],
+        "regions_with_san": [r["host"] for r in rows if r["san"]],
+        "regions_where_key_matches": sum(1 for r in rows if r["key_matches_cert"] is True),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    args = ap.parse_args()
+
+    bundle = load_cert_bundle()
+    hosts = bundle.available_regions()
+    if not hosts:
+        print("FAILED: no regions in the bundle store.", file=sys.stderr)
+        return 2
+
+    rows, failed = [], []
+    for host in hosts:
+        blobs = bundle.decrypt_region(host)
+        if not blobs:
+            failed.append(host)
+            continue
+        try:
+            rows.append(inspect_region(host, blobs))
+        except Exception as err:  # noqa: BLE001 — a broken region is a result, not a crash
+            failed.append(f"{host}: {type(err).__name__}: {err}")
+
+    if not rows:
+        print("FAILED: no region could be parsed.", file=sys.stderr)
+        return 2
+
+    result = {"summary": summarise(rows), "failed": failed, "regions": rows}
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+
+    s = result["summary"]
+    print(f"Regions in bundle: {s['regions']}   (unparseable: {len(failed)})")
+    print()
+    print(f"{'host':<52} {'CN':<10} {'serial':<20} {'days':>5} {'SPKI sha256':<16} key?")
+    print("-" * 118)
+    for r in sorted(rows, key=lambda r: r["host"]):
+        print(f"{r['host']:<52} {str(r['subject_cn']):<10} {r['serial_hex']:<20} "
+              f"{r['validity_days']:>5} {r['spki_sha256'][:16]:<16} "
+              f"{'yes' if r['key_matches_cert'] else 'NO'}")
+    print()
+    print("Cross-region comparison")
+    print(f"  distinct subjects .......... {s['distinct_subjects']}   {s['subjects']}")
+    print(f"  distinct issuers ........... {s['distinct_issuers']}   {s['issuers']}")
+    print(f"  distinct serials ........... {s['distinct_serials']}")
+    print(f"  distinct public keys (SPKI)  {s['distinct_spki']}")
+    print(f"  distinct CA certificates ... {s['distinct_ca_fingerprints']}")
+    print(f"  validity span (days) ....... {s['validity_days_min']} .. {s['validity_days_max']}")
+    print(f"  regions with a SAN ......... {len(s['regions_with_san'])}")
+    print(f"  private key matches cert ... {s['regions_where_key_matches']}/{s['regions']}")
+    print(f"  per-device markers in CN/SAN {s['regions_with_per_device_markers'] or 'none'}")
+    print()
+    sample = rows[0]
+    print(f"Sample region: {sample['host']}")
+    print(f"  subject ................ {sample['subject']}")
+    print(f"  issuer ................. {sample['issuer']}")
+    print(f"  SAN .................... {sample['san'] or 'absent'}")
+    print(f"  validity ............... {sample['not_before']} .. {sample['not_after']}")
+    print(f"  signature algorithm .... {sample['signature_algorithm']}")
+    print(f"  public key ............. {sample['public_key']}")
+    print(f"  key usage .............. {sample['key_usage'] or 'absent'}")
+    print(f"  extended key usage ..... {sample['extended_key_usage'] or 'absent'}")
+    print(f"  non-standard extensions  {sample['unusual_extensions'] or 'none'}")
+    print(f"  CA subject ............. {sample['ca_subject']}")
+    if failed:
+        print()
+        print("Unparseable regions:")
+        for f in failed:
+            print(f"  {f}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/enrollment_probe/step2_tls_probe.py
+++ b/tools/enrollment_probe/step2_tls_probe.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Step 2 — does the broker actually require the client certificate?
+
+The probe opens a TLS connection to the EMQX host and stops at the end of the
+handshake: it never sends an MQTT CONNECT and never authenticates. Nothing is
+written to the repository.
+
+Three variants, and the comparison between them is the whole point:
+
+  none        no client certificate at all;
+  bundled     the certificate shipped in `certs/store.json` for this region;
+  selfsigned  a throw-away RSA key and self-signed certificate generated here,
+              which no Chery CA has ever seen. This is the variant that decides
+              whether a user could bring their own locally generated material
+              instead of the redistributed bundle.
+
+**Why a completed handshake proves nothing on its own.** Under TLS 1.3 the client
+finishes its side of the handshake before the server has had a chance to judge the
+certificate it did or did not receive. A server configured with `verify_peer` and
+`fail_if_no_peer_cert` therefore lets `wrap_socket()` return successfully and only
+then drops the connection. The client sees "handshake_ok" followed by an immediate
+EOF. So after every successful handshake this probe waits, passively, and records
+what the server does: hold the connection open (accepted), close it (rejected), or
+send a TLS alert such as 116 `certificate_required`. Waiting and reading is not
+authenticating.
+
+Each variant is repeated a few times, because "the connection dropped" is exactly
+the kind of observation a single flaky run can fake.
+
+Usage:
+    python3 tools/enrollment_probe/step2_tls_probe.py [--host H] [--ports 8083,8883]
+                                                      [--variants none,bundled,selfsigned]
+                                                      [--repeat 3] [--json]
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import importlib.util
+import json
+import os
+import socket
+import ssl
+import sys
+import tempfile
+import time
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+PACKAGE = os.path.join(REPO, "custom_components", "omoda9")
+
+DEFAULT_HOST = "tspemqx-app-eu.cheryinternational.com"
+# 8083 is what the integration actually dials (const.py DEFAULTS); the others are
+# the conventional EMQX listeners — MQTT/TLS, alternative MQTT/TLS, WSS, plain MQTT.
+DEFAULT_PORTS = "8083,8883,8884,443,1883"
+VARIANTS = ("none", "bundled", "selfsigned")
+TIMEOUT = 10.0
+# How long to wait for the server to reveal its judgement after the handshake.
+# EMQX drops a rejected peer within milliseconds; a healthy MQTT listener waits
+# for the client to speak for far longer than this.
+LINGER = 4.0
+
+
+def load_cert_bundle():
+    spec = importlib.util.spec_from_file_location(
+        "_cert_bundle", os.path.join(PACKAGE, "cert_bundle.py"))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def make_selfsigned() -> dict[str, bytes]:
+    """A throw-away identity, generated here and trusted by nobody."""
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(x509.NameOID.COMMON_NAME, "enrollment-probe")])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert = (x509.CertificateBuilder()
+            .subject_name(name).issuer_name(name)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now - datetime.timedelta(minutes=5))
+            .not_valid_after(now + datetime.timedelta(days=1))
+            .sign(key, hashes.SHA256()))
+    return {
+        "client.pem": cert.public_bytes(serialization.Encoding.PEM),
+        "client.key": key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption()),
+    }
+
+
+def describe_peer_cert(sock: ssl.SSLSocket) -> dict:
+    """Server-side identity, used to tell the stack apart.
+
+    A self-hosted EMQX presents a leaf issued by the region's own CA; Aliyun IoT
+    Platform would present a `*.iot-as-mqtt.<region>.aliyuncs.com` certificate.
+    That difference decides whether a dynamic-registration path can exist at all.
+    """
+    der = sock.getpeercert(binary_form=True)
+    if not der:
+        return {}
+    try:
+        from cryptography import x509
+        cert = x509.load_der_x509_certificate(der)
+        try:
+            san = [f"{type(n).__name__}:{getattr(n, 'value', n)}" for n in
+                   cert.extensions.get_extension_for_class(
+                       x509.SubjectAlternativeName).value]
+        except x509.ExtensionNotFound:
+            san = []
+        return {"subject": cert.subject.rfc4514_string(),
+                "issuer": cert.issuer.rfc4514_string(),
+                "san": san,
+                "not_after": cert.not_valid_after_utc.isoformat()}
+    except Exception as err:  # noqa: BLE001
+        return {"parse_error": f"{type(err).__name__}: {err}"}
+
+
+def linger(sock: ssl.SSLSocket) -> dict:
+    """Wait passively and record the server's verdict on our handshake."""
+    started = time.monotonic()
+    sock.settimeout(LINGER)
+    try:
+        data = sock.recv(16)
+        elapsed = round(time.monotonic() - started, 3)
+        if data:
+            return {"outcome": "server_sent_bytes", "bytes": len(data), "after_s": elapsed}
+        return {"outcome": "server_closed", "after_s": elapsed,
+                "note": "clean EOF right after the handshake: the peer was rejected"}
+    except socket.timeout:
+        return {"outcome": "held_open", "after_s": round(time.monotonic() - started, 3),
+                "note": "the listener is waiting for us to speak: the peer was accepted"}
+    except ssl.SSLError as err:
+        return {"outcome": "tls_alert", "reason": getattr(err, "reason", None),
+                "after_s": round(time.monotonic() - started, 3), "detail": str(err)}
+    except OSError as err:
+        return {"outcome": "transport_error", "detail": f"{type(err).__name__}: {err}",
+                "after_s": round(time.monotonic() - started, 3)}
+
+
+def probe_once(host: str, port: int, material: dict[str, bytes] | None) -> dict:
+    result: dict = {}
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    # Server verification is deliberately off: the question is what the SERVER demands
+    # of US, and the integration already runs with tls_insecure_set(True).
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+
+    tmpdir = None
+    if material:
+        # OpenSSL can only load the key from the filesystem. It goes to a private
+        # temporary directory outside the repo and is overwritten and removed below.
+        tmpdir = tempfile.mkdtemp(prefix="enrollment_probe_")
+        os.chmod(tmpdir, 0o700)
+        paths = {}
+        for name in ("client.pem", "client.key"):
+            paths[name] = os.path.join(tmpdir, name)
+            with open(os.open(paths[name], os.O_CREAT | os.O_WRONLY, 0o600), "wb") as f:
+                f.write(material[name])
+        ctx.load_cert_chain(paths["client.pem"], paths["client.key"])
+
+    try:
+        raw = socket.create_connection((host, port), timeout=TIMEOUT)
+    except OSError as err:
+        _wipe(tmpdir)
+        return {"outcome": "tcp_failed", "error": f"{type(err).__name__}: {err}"}
+
+    try:
+        with ctx.wrap_socket(raw, server_hostname=host) as tls:
+            result.update(outcome="handshake_ok",
+                          tls_version=tls.version(),
+                          cipher=tls.cipher()[0] if tls.cipher() else None,
+                          alpn=tls.selected_alpn_protocol(),
+                          server_cert=describe_peer_cert(tls))
+            result["after_handshake"] = linger(tls)
+    except ssl.SSLError as err:
+        result.update(outcome="handshake_failed", error_class=type(err).__name__,
+                      reason=getattr(err, "reason", None),
+                      library=getattr(err, "library", None), detail=str(err))
+    except OSError as err:
+        result.update(outcome="transport_failed", error=f"{type(err).__name__}: {err}")
+    finally:
+        try:
+            raw.close()
+        except OSError:
+            pass
+        _wipe(tmpdir)
+    return result
+
+
+def _wipe(tmpdir: str | None) -> None:
+    if not tmpdir:
+        return
+    for name in os.listdir(tmpdir):
+        path = os.path.join(tmpdir, name)
+        try:
+            size = os.path.getsize(path)
+            with open(path, "r+b") as f:
+                f.write(b"\x00" * size)
+            os.remove(path)
+        except OSError:
+            pass
+    try:
+        os.rmdir(tmpdir)
+    except OSError:
+        pass
+
+
+def collapse(attempts: list[dict]) -> str:
+    """One label for a set of repeats — `mixed:` when they disagree."""
+    labels = []
+    for a in attempts:
+        if a["outcome"] != "handshake_ok":
+            labels.append(a["outcome"])
+        else:
+            labels.append(f"handshake_ok/{a['after_handshake']['outcome']}")
+    unique = sorted(set(labels))
+    return unique[0] if len(unique) == 1 else "mixed:" + "|".join(unique)
+
+
+ACCEPTED = "handshake_ok/held_open"
+REJECTED_AFTER_HANDSHAKE = "handshake_ok/server_closed"
+
+
+def serves_this_host(run: dict, host: str) -> bool | None:
+    """Is the certificate on this port actually the broker's, or another service?
+
+    Several ports on the same address answer TLS with a completely different
+    service. A port that presents a certificate for another hostname says nothing
+    about the broker's client-certificate policy, and reporting it as if it did
+    would be the easiest way to reach a wrong conclusion.
+    """
+    cert = (run.get("attempts") or [{}])[0].get("server_cert") or {}
+    names = [n.split(":", 1)[-1] for n in cert.get("san", [])]
+    if not names and not cert.get("subject"):
+        return None
+    return host in names
+
+
+def verdict(matrix: dict[int, dict[str, str]], foreign: dict[int, str]) -> list[str]:
+    """Read the variant × port matrix into plain statements."""
+    lines = []
+    for port, by_variant in sorted(matrix.items()):
+        if port in foreign:
+            lines.append(f"port {port}: a different service answers here "
+                         f"({foreign[port]}), not the broker — no conclusion about the "
+                         f"broker's certificate policy.")
+            continue
+        none = by_variant.get("none")
+        bundled = by_variant.get("bundled")
+        selfsigned = by_variant.get("selfsigned")
+        if none is None:
+            continue
+        if none.startswith("tcp_failed") or none.startswith("transport"):
+            lines.append(f"port {port}: not reachable ({none}) — no conclusion.")
+            continue
+        if none == ACCEPTED:
+            lines.append(f"port {port}: DECISIVE — the listener accepts a connection "
+                         f"with NO client certificate. The certificate is irrelevant "
+                         f"to the transport.")
+        elif none == REJECTED_AFTER_HANDSHAKE and bundled == ACCEPTED:
+            lines.append(f"port {port}: the broker REQUIRES a client certificate. The "
+                         f"TLS 1.3 handshake completes either way, but without one the "
+                         f"server drops the connection immediately, and with the "
+                         f"bundled certificate it holds it open.")
+        elif "CERTIFICATE_REQUIRED" in str(none).upper():
+            lines.append(f"port {port}: the broker requires a client certificate "
+                         f"(alert 116 certificate_required).")
+        else:
+            lines.append(f"port {port}: no certificate -> {none}"
+                         f"{f'; bundled -> {bundled}' if bundled else ''}.")
+        if selfsigned is not None and none == REJECTED_AFTER_HANDSHAKE:
+            if selfsigned == ACCEPTED:
+                lines.append(f"port {port}: and a SELF-SIGNED certificate generated "
+                             f"locally is accepted too — the broker demands a "
+                             f"certificate but does not check who signed it. Users "
+                             f"could generate their own; the bundle is not needed.")
+            else:
+                lines.append(f"port {port}: a self-signed certificate is rejected "
+                             f"({selfsigned}) — the material must chain to the region "
+                             f"CA, so it cannot simply be generated locally.")
+    return lines
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--host", default=DEFAULT_HOST)
+    ap.add_argument("--ports", default=DEFAULT_PORTS)
+    ap.add_argument("--variants", default=",".join(VARIANTS))
+    ap.add_argument("--repeat", type=int, default=3)
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    ports = [int(p) for p in args.ports.split(",") if p.strip()]
+    variants = [v.strip() for v in args.variants.split(",") if v.strip()]
+    for v in variants:
+        if v not in VARIANTS:
+            print(f"FAILED: unknown variant {v!r}.", file=sys.stderr)
+            return 2
+
+    try:
+        addresses = sorted({ai[4][0] for ai in socket.getaddrinfo(args.host, None)})
+    except socket.gaierror as err:
+        print(f"FAILED: {args.host} does not resolve ({err}).", file=sys.stderr)
+        return 2
+
+    materials: dict[str, dict[str, bytes] | None] = {"none": None}
+    if "bundled" in variants:
+        materials["bundled"] = load_cert_bundle().decrypt_region(args.host)
+        if materials["bundled"] is None:
+            print(f"NOTE: no bundled certificate for {args.host}; skipping that variant.",
+                  file=sys.stderr)
+            variants = [v for v in variants if v != "bundled"]
+    if "selfsigned" in variants:
+        materials["selfsigned"] = make_selfsigned()
+
+    runs, matrix = [], {}
+    for port in ports:
+        matrix[port] = {}
+        for variant in variants:
+            attempts = [probe_once(args.host, port, materials[variant])
+                        for _ in range(args.repeat)]
+            label = collapse(attempts)
+            matrix[port][variant] = label
+            runs.append({"port": port, "variant": variant, "label": label,
+                         "attempts": attempts})
+            # A port that will not even accept TCP will not accept it for the other
+            # variants either: skip them instead of burning three timeouts each.
+            if variant == "none" and label == "tcp_failed":
+                break
+
+    foreign = {}
+    for run in runs:
+        if run["variant"] != "none":
+            continue
+        if serves_this_host(run, args.host) is False:
+            cert = run["attempts"][0].get("server_cert") or {}
+            foreign[run["port"]] = cert.get("san") or cert.get("subject")
+
+    result = {"host": args.host, "resolves_to": len(addresses),
+              "repeat": args.repeat, "matrix": matrix, "foreign_services": foreign,
+              "verdict": verdict(matrix, foreign), "runs": runs}
+
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+
+    print(f"Host: {args.host}  ({len(addresses)} address(es), {args.repeat} attempts each)")
+    print()
+    print(f"{'port':<6} {'variant':<12} {'outcome':<34} {'TLS':<9} cipher")
+    print("-" * 92)
+    for run in runs:
+        first = run["attempts"][0]
+        print(f"{run['port']:<6} {run['variant']:<12} {run['label']:<34} "
+              f"{first.get('tls_version') or '-':<9} {first.get('cipher') or '-'}")
+    print()
+    seen = set()
+    for run in runs:
+        sc = (run["attempts"][0].get("server_cert") or {})
+        if not sc.get("subject") or run["port"] in seen:
+            continue
+        seen.add(run["port"])
+        print(f"Server certificate on port {run['port']}:")
+        print(f"  subject {sc['subject']}")
+        print(f"  issuer  {sc['issuer']}")
+        print(f"  SAN     {sc.get('san') or 'absent'}")
+        print()
+    for line in result["verdict"]:
+        print(f"* {line}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/enrollment_probe/step2_tls_probe.py
+++ b/tools/enrollment_probe/step2_tls_probe.py
@@ -149,6 +149,12 @@ def probe_once(host: str, port: int, material: dict[str, bytes] | None) -> dict:
     # of US, and the integration already runs with tls_insecure_set(True).
     ctx.check_hostname = False
     ctx.verify_mode = ssl.CERT_NONE
+    # Floor at TLS 1.2. PROTOCOL_TLS_CLIENT alone still permits 1.0 and 1.1, which this
+    # probe has no use for: the broker negotiates 1.3, and the measurement that matters
+    # here is whether the connection SURVIVES the handshake, not which version carried it.
+    # Saying so explicitly also keeps py/insecure-protocol switched on for the whole
+    # repository, where it guards the part that actually talks to a car.
+    ctx.minimum_version = ssl.TLSVersion.TLSv1_2
 
     tmpdir = None
     if material:

--- a/tools/enrollment_probe/step3_response_scan.py
+++ b/tools/enrollment_probe/step3_response_scan.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Step 3 — is there per-device credential material in the provisioning responses?
+
+Runs the read-only half of the provisioning chain implemented in
+`custom_components/omoda9/core/provision.py` and scans the full JSON responses for
+anything that could be a per-device enrollment: a certificate, a CSR, a keystore,
+or the product/device/secret triple that Aliyun IoT Platform hands out through its
+dynamic registration.
+
+**What it does NOT do.** No `setVecDefault`, no `checkPassword`, no PIN, no
+`taskId`, no `/asc/vehicleControl/*`. Nothing reaches the car. By default it does
+not refresh the session either: it copies the token file to a temporary location
+and uses the existing access token as-is, so the live Home Assistant session is
+never rotated underneath a running instance. If that token is expired the probe
+stops and says so — it never asks for an OTP.
+
+**What it prints.** Dotted paths and the *shape* of values: type, length, an
+eight-character prefix. Never a whole value, and never a prefix of anything that
+carries an account identifier.
+
+Environment (same names `provision.py` already uses):
+    VIN, OMODA_TOKEN_PATH   required
+    OMODA_BFF, TSP_HOST, CHANNEL_ID, OMODA_COUNTRY_ID, OMODA_TENANT_CODE  optional
+
+Usage:
+    python3 tools/enrollment_probe/step3_response_scan.py [--allow-refresh] [--json]
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+import types
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+COMPONENTS = os.path.join(REPO, "custom_components")
+
+# Long base64 that starts a DER structure, or the base64 of "-----BEGIN".
+BLOB_PATTERNS = {
+    "der_base64": re.compile(r"MII[A-Za-z0-9+/]{40,}"),
+    "pem_base64": re.compile(r"LS0tLS1CRUdJTi"),
+    "pem_literal": re.compile(r"-----BEGIN [A-Z ]+-----"),
+}
+LONG_STRING = 200
+
+# Key names that would betray an enrollment. `productKey`/`deviceName`/`deviceSecret`
+# together are the Aliyun IoT dynamic-registration triple.
+KEY_MARKERS = (
+    "cert", "pem", "csr", "p12", "keystore", "productkey", "devicename",
+    "devicesecret", "iotid", "clientid", "mqttusername", "mqttpassword",
+)
+# Keys whose values are account data: their shape may be reported, never a prefix.
+SENSITIVE_KEYS = (
+    "vin", "token", "phone", "mobile", "mail", "password", "secret", "pin",
+    "lat", "lon", "lng", "address", "idcard", "username", "nickname", "realname",
+)
+
+
+def load_core():
+    """Import `omoda9.core.*` without executing the integration's `__init__.py`.
+
+    `custom_components/omoda9/__init__.py` imports Home Assistant, which is not
+    installed here. Registering a bare package object under the right name lets the
+    submodules import each other with their normal relative imports.
+    """
+    if COMPONENTS not in sys.path:
+        sys.path.insert(0, COMPONENTS)
+    pkg = types.ModuleType("omoda9")
+    pkg.__path__ = [os.path.join(COMPONENTS, "omoda9")]
+    sys.modules.setdefault("omoda9", pkg)
+    core = importlib.import_module("omoda9.core")
+    return (core,
+            importlib.import_module("omoda9.core.wake"),
+            importlib.import_module("omoda9.core.provision"),
+            importlib.import_module("omoda9.core.omoda_auth"),
+            importlib.import_module("omoda9.core.context"))
+
+
+def collect_secrets(ctx, access_token: str | None) -> set[str]:
+    """Values that must never appear, not even as a prefix, in this output."""
+    out = {ctx.vin, ctx.tuserid, ctx.email, ctx.phone, ctx.pin, access_token}
+    return {s for s in out if s and isinstance(s, str) and len(s) >= 4}
+
+
+def shape(key: str, value, secrets: set[str]) -> dict:
+    text = value if isinstance(value, str) else json.dumps(value, ensure_ascii=False)
+    info = {"type": type(value).__name__, "length": len(text)}
+    sensitive = (any(m in key.lower() for m in SENSITIVE_KEYS)
+                 or any(s in text for s in secrets))
+    info["prefix8"] = "<redacted>" if sensitive else text[:8]
+    return info
+
+
+def scan(node, secrets: set[str], path: str = "$") -> list[dict]:
+    """Walk the structure and report every path that looks like key material."""
+    found: list[dict] = []
+    if isinstance(node, dict):
+        for key, value in node.items():
+            child = f"{path}.{key}"
+            reasons = [f"key-name:{m}" for m in KEY_MARKERS if m in key.lower()]
+            if reasons and not isinstance(value, (dict, list)):
+                found.append({"path": child, "reasons": reasons,
+                              **shape(key, value, secrets)})
+            found += scan(value, secrets, child)
+    elif isinstance(node, list):
+        for i, value in enumerate(node):
+            found += scan(value, secrets, f"{path}[{i}]")
+    elif isinstance(node, str):
+        reasons = [name for name, rx in BLOB_PATTERNS.items() if rx.search(node)]
+        if len(node) > LONG_STRING:
+            reasons.append(f"long-string:>{LONG_STRING}")
+        if reasons:
+            key = path.rsplit(".", 1)[-1]
+            found.append({"path": path, "reasons": reasons, **shape(key, node, secrets)})
+    return found
+
+
+def key_census(node, path: str = "$", acc: dict | None = None) -> dict:
+    """Every key name in the payload, with its path. Cheap, and it makes an absence
+    verifiable: `productKey` missing is only a finding if you can show the full list."""
+    acc = {} if acc is None else acc
+    if isinstance(node, dict):
+        for key, value in node.items():
+            acc.setdefault(key, []).append(f"{path}.{key}")
+            key_census(value, f"{path}.{key}", acc)
+    elif isinstance(node, list):
+        for i, value in enumerate(node):
+            key_census(value, f"{path}[{i}]", acc)
+    return acc
+
+
+def build_ctx(context_mod, token_path: str):
+    ctx = context_mod.ctx_da_environ()
+    ctx.token_path = token_path
+    return ctx
+
+
+def capture_login(wake, auth, ctx) -> tuple[int, dict]:
+    """The BFF login call, keeping the body that `_bff_login` throws away.
+
+    This is the same request the integration already makes every session check —
+    read-only, and the most plausible place for a broker credential to ride along.
+    """
+    import requests
+    path = "/tsp/v1/app/auth/login"
+    token = wake._access_token(ctx)
+    headers = auth.headers_post(path, ctx=ctx, extra={
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json; charset=UTF-8",
+        "Accept": "application/json, text/plain, */*"})
+    r = requests.post(ctx.bff + path, data=json.dumps({"channelId": ctx.channel_id}),
+                      headers=headers, timeout=20)
+    try:
+        return r.status_code, r.json()
+    except ValueError:
+        return r.status_code, {"_raw_len": len(r.text)}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--allow-refresh", action="store_true",
+                    help="permit a refresh_token rotation on the REAL token file "
+                         "(off by default: rotation invalidates a running instance)")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    real_token = os.environ.get("OMODA_TOKEN_PATH", "")
+    if not real_token or not os.path.isfile(real_token):
+        print("FAILED: OMODA_TOKEN_PATH is not set or does not point at a file.",
+              file=sys.stderr)
+        return 2
+    if not os.environ.get("VIN"):
+        print("FAILED: VIN is not set.", file=sys.stderr)
+        return 2
+
+    core, wake, provision, auth, context_mod = load_core()
+
+    tmpdir = None
+    if args.allow_refresh:
+        token_path = real_token
+        print("NOTE: refresh enabled — the server will rotate the refresh token.",
+              file=sys.stderr)
+    else:
+        tmpdir = tempfile.mkdtemp(prefix="enrollment_probe_")
+        token_path = os.path.join(tmpdir, "token.json")
+        # copyfile + utime, not copy2: the token lives on a network share whose
+        # flags cannot be copied, and the only attribute that matters here is the
+        # mtime — `wake._eta_token` reads the token's age from it.
+        shutil.copyfile(real_token, token_path)
+        stat = os.stat(real_token)
+        os.utime(token_path, (stat.st_atime, stat.st_mtime))
+
+    try:
+        ctx = build_ctx(context_mod, token_path)
+        secrets = collect_secrets(ctx, wake._access_token(ctx))
+
+        age, lifetime = wake._eta_token(ctx)
+        session = {"token_present": bool(wake._access_token(ctx)),
+                   "token_age_s": round(age), "token_lifetime_s": lifetime,
+                   "expired_by_age": bool(lifetime and age >= lifetime)}
+
+        user_token, tuser_id = wake._bff_login(ctx, _allow_refresh=args.allow_refresh)
+        if not user_token:
+            result = {"status": "STOPPED", "session": session,
+                      "reason": "the BFF refused the stored session; a new OTP would be "
+                                "needed and this probe must not ask for one"}
+            print(json.dumps(result, indent=2) if args.json
+                  else f"STOPPED: {result['reason']}\nsession: {session}")
+            return 1
+        session["login"] = "ok"
+        session["tuser_id_present"] = bool(tuser_id)
+
+        captures = {}
+        status, body = capture_login(wake, auth, ctx)
+        captures["auth/login"] = {"http": status, "body": body}
+        status, body = provision.get_tuser_id()
+        captures["auth/getTuserId"] = {"http": status, "body": body}
+        status, body = provision.query_list()
+        captures["vmc/queryList"] = {"http": status, "body": body}
+
+        report = {"status": "OK", "session": session, "endpoints": {}}
+        for name, cap in captures.items():
+            census = key_census(cap["body"])
+            hits = scan(cap["body"], secrets)
+            report["endpoints"][name] = {
+                "http": cap["http"],
+                "code": cap["body"].get("code") if isinstance(cap["body"], dict) else None,
+                "key_count": len(census),
+                "keys": sorted(census),
+                "hits": hits,
+                "markers_present": {m: any(m in k.lower() for k in census)
+                                    for m in KEY_MARKERS},
+            }
+
+        report["not_implemented"] = {
+            "loginTSP": "no HTTP implementation exists in core/provision.py. The module "
+                        "docstring records that the app's getTspToken()/loginTSP is a "
+                        "native call, a no-op in the DEX, so there is nothing in this "
+                        "codebase to replay and no observed request to imitate.",
+        }
+    finally:
+        if tmpdir:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 0
+
+    print(f"Session: token present: {'yes' if session['token_present'] else 'no'}, "
+          f"age {session['token_age_s']}s of {session['token_lifetime_s']}s, "
+          f"login: {session.get('login')}")
+    print()
+    for name, ep in report["endpoints"].items():
+        print(f"--- {name}   http={ep['http']} code={ep['code']} "
+              f"({ep['key_count']} distinct keys)")
+        if ep["hits"]:
+            for hit in ep["hits"]:
+                print(f"    HIT {hit['path']}  {hit['reasons']}  "
+                      f"type={hit['type']} len={hit['length']} prefix={hit['prefix8']!r}")
+        else:
+            print("    no blob and no marker key")
+        absent = [m for m, present in ep["markers_present"].items() if not present]
+        present = [m for m, ok in ep["markers_present"].items() if ok]
+        print(f"    marker keys present: {present or 'none'}")
+        print(f"    marker keys absent:  {', '.join(absent)}")
+        print()
+    print("loginTSP: " + report["not_implemented"]["loginTSP"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/enrollment_probe/step4_keygen_scan.py
+++ b/tools/enrollment_probe/step4_keygen_scan.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Step 4 — is there any client-side key or CSR generation, anywhere?
+
+An enrollment based on a certificate signing request has a signature you cannot
+hide: something, somewhere, has to generate a key pair and build a PKCS#10
+request. This step looks for that signature across the codebase and across any
+reverse-engineering notes handed to it with `--extra`.
+
+A total absence is not a weak result. If nothing in the material generates a key
+pair, then no CSR-based enrollment was ever observed in the app, and one cannot be
+implemented by replaying what we know.
+
+Read-only: it opens files and counts matches. Nothing is written and no network
+is touched.
+
+Usage:
+    python3 tools/enrollment_probe/step4_keygen_scan.py [--extra DIR ...] [--json]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+PATTERNS = {
+    "java_keypair": r"KeyPairGenerator|generateKeyPair|getInstance\(\s*[\"']RSA[\"']",
+    "pkcs10_csr": r"PKCS\s*#?10|CertificationRequest|CertificateSigningRequest|"
+                  r"createCertificateRequest|\bCSR\b|csr[_A-Z]",
+    "bouncy_castle": r"bouncycastle|spongycastle|BouncyCastleProvider|\bBKS\b",
+    "keystore_build": r"KeyStore\.getInstance|keytool|\.jks\b|\.p12\b|\.pfx\b|"
+                      r"setKeyEntry|load_pkcs12",
+    "python_keygen": r"generate_private_key|CertificateSigningRequestBuilder|"
+                     r"CertificateBuilder|rsa\.generate|ec\.generate_private_key",
+    "openssl_cli": r"openssl\s+(req|genrsa|genpkey|x509|pkcs12)",
+    "enrollment_words": r"\benroll(ment)?\b|dynamic\s*regist|deviceSecret|productKey|"
+                        r"\bdeviceName\b|iotId",
+}
+
+TEXT_SUFFIXES = (".py", ".md", ".js", ".ts", ".json", ".yaml", ".yml", ".txt",
+                 ".java", ".kt", ".dart", ".smali", ".xml", ".sh", ".toml", ".cfg")
+# `store.json` is the obfuscated certificate bundle: megabytes of base64 that match
+# nothing meaningful and drown the output. The other two exclusions are this
+# investigation's own output — `step2_tls_probe.py` genuinely generates a key pair,
+# and `enrollment-findings.md` names every pattern below while reporting that none
+# of them was found. Scanning either would manufacture the very evidence we are
+# looking for: the first run of this script, before the report existed, found one
+# match; with the report in the tree it found fourteen, all of them our own prose.
+SKIP_PARTS = (os.sep + ".git" + os.sep, os.sep + "__pycache__" + os.sep,
+              os.sep + "node_modules" + os.sep, os.sep + ".pytest_cache" + os.sep,
+              os.sep + "certs" + os.sep + "store.json",
+              os.sep + "tools" + os.sep + "enrollment_probe" + os.sep,
+              os.sep + "docs" + os.sep + "enrollment-findings.md")
+MAX_BYTES = 4_000_000
+
+
+def walk(root: str):
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames
+                       if d not in (".git", "__pycache__", "node_modules", ".pytest_cache")]
+        for name in filenames:
+            path = os.path.join(dirpath, name)
+            if any(part in path for part in SKIP_PARTS):
+                continue
+            if not path.endswith(TEXT_SUFFIXES):
+                continue
+            try:
+                if os.path.getsize(path) > MAX_BYTES:
+                    continue
+            except OSError:
+                continue
+            yield path
+
+
+def scan_root(root: str, compiled: dict[str, re.Pattern]) -> tuple[dict, int]:
+    hits: dict[str, list[str]] = {name: [] for name in compiled}
+    files = 0
+    for path in walk(root):
+        files += 1
+        try:
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                for lineno, line in enumerate(fh, 1):
+                    for name, rx in compiled.items():
+                        if rx.search(line):
+                            rel = os.path.relpath(path, root)
+                            hits[name].append(f"{rel}:{lineno}: {line.strip()[:120]}")
+        except OSError:
+            continue
+    return hits, files
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--extra", action="append", default=[],
+                    help="additional directory to scan (reverse-engineering notes)")
+    ap.add_argument("--max-shown", type=int, default=8)
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    compiled = {name: re.compile(rx, re.IGNORECASE) for name, rx in PATTERNS.items()}
+    roots = [REPO] + [os.path.abspath(p) for p in args.extra]
+
+    report = {"roots": [], "totals": {name: 0 for name in PATTERNS}}
+    for root in roots:
+        if not os.path.isdir(root):
+            report["roots"].append({"root": root, "error": "not a directory"})
+            continue
+        hits, files = scan_root(root, compiled)
+        for name, lines in hits.items():
+            report["totals"][name] += len(lines)
+        report["roots"].append({"root": root, "files_scanned": files,
+                                "hits": {n: len(v) for n, v in hits.items()},
+                                "samples": {n: v[:args.max_shown]
+                                            for n, v in hits.items() if v}})
+
+    generating = ("java_keypair", "pkcs10_csr", "bouncy_castle", "keystore_build",
+                  "python_keygen", "openssl_cli")
+    total_generating = sum(report["totals"][n] for n in generating)
+    report["verdict"] = (
+        "No key-pair or CSR generation anywhere in the scanned material: a CSR-based "
+        "enrollment cannot exist here, and none was ever observed in the app."
+        if total_generating == 0 else
+        f"{total_generating} match(es) for key or CSR generation — inspect the samples "
+        f"before concluding anything.")
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 0
+
+    for entry in report["roots"]:
+        if entry.get("error"):
+            print(f"{entry['root']}: {entry['error']}")
+            continue
+        print(f"{entry['root']}  ({entry['files_scanned']} text files)")
+        for name in PATTERNS:
+            count = entry["hits"][name]
+            print(f"  {name:<20} {count}")
+            for sample in entry.get("samples", {}).get(name, []):
+                print(f"      {sample}")
+        print()
+    print(report["verdict"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Relates to #41 — the evidence behind it, so the conclusion can be disagreed with rather than taken on trust.

Nothing in `custom_components/` changes. The scripts live in `tools/` so they never reach the HACS payload, which is built from the package directory alone.

## What is here

| script | question | network |
|---|---|---|
| `step1_cert_inspect.py` | per-device identity, or per-region constant? | none |
| `step2_tls_probe.py` | does the broker demand a client certificate, and does it check who signed it? | TLS handshake only |
| `step3_response_scan.py` | do the provisioning responses carry credential material? | read-only BFF calls |
| `step4_keygen_scan.py` | does anything generate a key pair or a CSR? | none |

Plus `docs/enrollment-findings.md`: the reasoning, the numbers, and the limits.

## The one thing to read carefully, if you read one thing

**Step 2 nearly produced the opposite answer.** On port 8083 the TLS 1.3 handshake completes with **no client certificate at all**. Reading only that gives "the certificate is irrelevant, remove the bundle" — the first row of the decision table in #41 — and it is wrong.

Under TLS 1.3 the client finishes its side before the server has judged what it received, so the verdict arrives afterwards. Three attempts per variant, all consistent:

| what we present | what the broker does |
|---|---|
| nothing | handshake OK, **connection closed within milliseconds** |
| the bundled certificate | handshake OK, **connection held open** |
| a self-signed certificate made on the spot | handshake OK, **connection closed** |

EMQX with `verify_peer` and `fail_if_no_peer_cert`. It never sends alert 116, which is why the probe waits and reads instead of trusting the handshake result. And the self-signed row is the one that closes the question: the broker does not want *a* certificate, it wants one chaining to the region CA.

## Safety rules the scripts obey

No command, no `taskId`, no PIN, no OTP — nothing reaches the car. `step3` reuses the stored session and does **not** refresh it by default: it copies the token file so a running instance never has its refresh token rotated underneath it, and an expired token stops the probe rather than prompting. Values are reported by shape — type, length, an eight-character prefix — and the prefix is suppressed for anything carrying an account identifier. The bundle is de-obfuscated in memory; when OpenSSL needs a key on disk it goes to a private temporary directory and is overwritten and removed.

## Limits, stated in the report rather than implied

One region probed on the network — the EU broker this account uses; step 1 covers all 40. Ports 8883, 8884 and 1883 timed out at TCP level, and a timeout is not a closed port, so nothing is concluded from them. `loginTSP` could not be run at all: there is no HTTP call to replay, since it is native and a no-op in the DEX. That is reported as a result rather than filled in by inference — an invented result would be worse than a missing one, given a decision depends on this.

Two things surfaced that belong elsewhere and are recorded, not acted on: `tls_insecure_set(True)` in `coordinator.py` is no longer needed (full verification against the bundled CA with `check_hostname` on succeeds today), and `certs_dir` is derived from `DOMAIN`, so removing the bundle and renaming the domain must never share a release.

---

*Per the convention: the probes were written and run by the agent I drive, including the control that overturned its own first reading. Deciding to test the hypothesis rather than assume it, and what to do about the answer, is mine.*
