### PR TITLE
docs: say how to start, for someone who has not contributed here before

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,10 +199,14 @@ rule ships with the thing that holds it up rather than with a request to remembe
 
 ## The commands
 
-`master` is protected: no direct pushes. Everything below assumes the remote is
-called `origin`. Replace `<name>` placeholders.
+`master` is protected and it is the only long-lived branch. There is no `develop`:
+everything is cut from `master` and comes back to it as a pull request. Nobody pushes to
+it, including the people who could. Replace `<name>` placeholders.
 
-**Once, to get set up**
+**Once, to get set up. Which of the two you are decides everything after it.**
+
+*If you have write access here* (you are one of the maintainers), clone the repository
+itself and work in branches of it:
 
 ```bash
 git clone https://github.com/chery-connect-ha/omoda9-ha.git
@@ -210,23 +214,42 @@ cd omoda9-ha
 gh auth status || gh auth login     # the GitHub CLI, for pull requests
 ```
 
-**Start a piece of work — always from an up-to-date `master`**
+*If you do not* (you are contributing from outside, which is the normal case), you cannot
+push a branch here at all. Fork first, and keep a second remote pointing at this
+repository so you can stay current with it:
 
 ```bash
-git fetch origin
-git switch -c fix/<short-name> origin/master
+gh repo fork chery-connect-ha/omoda9-ha --clone     # creates your fork and clones it
+cd omoda9-ha
+git remote -v                                       # origin = your fork, upstream = here
+```
+
+**Do not commit on the `master` of your fork.** It is the one mistake that costs you
+something you cannot undo cheaply: a pull request opened from `master` follows that branch,
+so every later commit you make lands inside the open pull request, and you can have only
+one going at a time. Branch, always, even for a single file.
+
+**Start a piece of work: always from an up-to-date `master`, never from your own.**
+
+```bash
+git fetch upstream                                  # or `origin` if you cloned directly
+git switch -c fix/<short-name> upstream/master      # or `origin/master`
 ```
 
 Name it for the behaviour, not the file: `fix/charge-energy-undercount`, not
 `fix/coordinator`.
 
-**Keep it current while it is open — not only when it conflicts**
+**Keep it current while it is open, not only when it conflicts**
 
 ```bash
-git fetch origin
-git merge origin/master
+git fetch upstream                                  # or `origin` if you cloned directly
+git merge upstream/master                           # or `origin/master`
 git push
 ```
+
+This is not tidiness. `master` requires a branch to be current before it can be merged, so
+a branch that sits behind is not mergeable no matter how green its checks are, and the
+person who finds out is you, at the end.
 
 Do this whenever `master` has moved and your branch has been open more than a day
 or two. Conflicts are the obvious reason and the least important one. The real

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,9 +225,22 @@ git remote -v                                       # origin = your fork, upstre
 ```
 
 **Do not commit on the `master` of your fork.** It is the one mistake that costs you
-something you cannot undo cheaply: a pull request opened from `master` follows that branch,
-so every later commit you make lands inside the open pull request, and you can have only
-one going at a time. Branch, always, even for a single file.
+something you cannot undo cheaply, and it has two separate consequences.
+
+The first is that a pull request opened from `master` follows that branch, so every later
+commit you make lands inside the open pull request, and you can have only one going at a
+time.
+
+The second destroyed somebody's work here on 6 September 2026, so it is written down in
+detail rather than as a warning. **Do not sync your fork while your own commits are on its
+`master`.** Once this repository's `master` has moved, your fork cannot fast-forward, and
+the Sync fork button in the browser offers "Discard commits" as the way through. Taking it
+does exactly what it says: the commits go, the pull request empties, and GitHub closes it
+in the same second. Nothing warns you first, and asking someone to "bring `master` into
+your branch" without giving them the commands leads them straight to that button.
+
+Branch, always, even for a single file. Then syncing your fork is harmless, because your
+work is not on the branch being synced.
 
 **Start a piece of work: always from an up-to-date `master`, never from your own.**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,6 +198,19 @@ question as who can review what.
 
 ## The mechanics
 
+**If this is your first change here, start with the shape of the repository, because
+getting it wrong costs you a rewrite rather than a correction.** There is one long-lived
+branch, `master`, and no `develop`. It is protected: nobody pushes to it, maintainers
+included, and everything arrives as a pull request. If you are contributing from outside,
+you cannot push a branch here at all, so you fork first and open the pull request from
+your fork.
+
+The part people get wrong, and it has already happened here: **do not commit on the
+`master` of your own fork.** Make a branch, even for a one-file change. A pull request
+opened from `master` follows that branch, so anything else you commit afterwards lands
+inside the open pull request, and you are limited to one at a time. `AGENTS.md` has the
+exact commands for both cases, fork and clone.
+
 If you are working with a coding agent — and most of us are — point it at
 [`AGENTS.md`](AGENTS.md) before it touches anything. It carries the invariants
 above plus the literal git and GitHub commands for branching, opening a pull

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,11 +205,16 @@ included, and everything arrives as a pull request. If you are contributing from
 you cannot push a branch here at all, so you fork first and open the pull request from
 your fork.
 
-The part people get wrong, and it has already happened here: **do not commit on the
-`master` of your own fork.** Make a branch, even for a one-file change. A pull request
-opened from `master` follows that branch, so anything else you commit afterwards lands
-inside the open pull request, and you are limited to one at a time. `AGENTS.md` has the
-exact commands for both cases, fork and clone.
+The part people get wrong, and it has already cost somebody their work here: **do not
+commit on the `master` of your own fork.** Make a branch, even for a one-file change.
+
+Two things go wrong otherwise. A pull request opened from `master` follows that branch, so
+anything you commit afterwards lands inside the open pull request. And the moment this
+repository's `master` moves ahead of yours, syncing your fork can no longer fast-forward,
+so the button offers to discard your commits instead: take it and the work is gone and the
+pull request closes itself. On a branch, syncing your fork is harmless.
+
+`AGENTS.md` has the exact commands for both cases, fork and clone.
 
 If you are working with a coding agent — and most of us are — point it at
 [`AGENTS.md`](AGENTS.md) before it touches anything. It carries the invariants


### PR DESCRIPTION
The setup instructions in `AGENTS.md` assumed the reader could push a branch to this
repository. Most people cannot: they are contributing from outside, and `git clone`
followed by `git switch -c` leaves them holding a branch with nowhere to send it. The
fork case was simply never written down.

**This changes no rules.** It describes what the repository already does. Nothing here
asks anyone to work differently.

### What it adds

- **The two starting situations, split.** Maintainers clone; everybody else forks, with
  `upstream` kept as a second remote so they can stay current. Literal commands for both.
- **The mistake that has already been made here: committing on the `master` of your own
  fork.** #50 arrives that way, and it is not the contributor's fault, because we never
  said. A pull request opened from `master` follows that branch, so every later commit
  lands inside the open pull request and you can only have one at a time. Undoing it means
  rewriting a branch someone may already have reviewed.
- **That there is one long-lived branch and no `develop`.** Worth saying out loud, since
  it is the first thing an experienced contributor will assume in the other direction.
- **That a branch which sits behind is not mergeable however green its checks are**, now
  that `master` requires branches to be current. Every one of the ten pull requests open
  last week was between 11 and 33 commits behind.

`CONTRIBUTING.md` gets the same thing in three paragraphs of prose, for the person who
reads that file rather than the agent one.

### Why now

Two of the three pull requests merged today needed a maintainer to resolve conflicts on
somebody else's branch, and the fourth open one comes from a fork's `master`. None of that
is carelessness: it is a document that told people how to do the thing only after assuming
they already could.
