### PR TITLE
fix(config): label the four region fields the password login was already drawing

### DIFF
--- a/custom_components/omoda9/strings.json
+++ b/custom_components/omoda9/strings.json
@@ -118,15 +118,22 @@
         "title": "Sign in with password",
         "description": "Enter your account email, password and vehicle PIN — no OTP code needed. VIN and account ID are detected automatically. The password is used once to sign in and is never stored.{reason}",
         "data": {
+          "preset": "Brand / region preset",
           "email": "Account email",
           "pin": "Vehicle control PIN",
           "password": "Account password",
+          "language": "Language (OTP emails / SMS)",
           "bff": "BFF endpoint (region)",
+          "tenant_code": "Tenant code (advanced)",
+          "country_id": "Country ID (advanced)",
           "tsp_host": "TSP console host (region)",
           "car_mqtt_host": "Vehicle MQTT broker host (region)",
           "car_mqtt_port": "Vehicle MQTT broker port (region)",
           "channel_id": "Channel ID (region)",
           "certs_src": "Folder with mutual-TLS certs to import (optional)"
+        },
+        "data_description": {
+          "preset": "Omoda/Jaecoo (Europe) and Chery (Europe) fill in everything automatically. Choose Custom to set the BFF endpoint, tenant code, country/channel IDs, MQTT host and certs by hand for any other region or brand."
         }
       },
       "reauth_password": {

--- a/custom_components/omoda9/translations/en.json
+++ b/custom_components/omoda9/translations/en.json
@@ -118,15 +118,22 @@
         "title": "Sign in with password",
         "description": "Enter your account email, password and vehicle PIN — no OTP code needed. VIN and account ID are detected automatically. The password is used once to sign in and is never stored.{reason}",
         "data": {
+          "preset": "Brand / region preset",
           "email": "Account email",
           "pin": "Vehicle control PIN",
           "password": "Account password",
+          "language": "Language (OTP emails / SMS)",
           "bff": "BFF endpoint (region)",
+          "tenant_code": "Tenant code (advanced)",
+          "country_id": "Country ID (advanced)",
           "tsp_host": "TSP console host (region)",
           "car_mqtt_host": "Vehicle MQTT broker host (region)",
           "car_mqtt_port": "Vehicle MQTT broker port (region)",
           "channel_id": "Channel ID (region)",
           "certs_src": "Folder with mutual-TLS certs to import (optional)"
+        },
+        "data_description": {
+          "preset": "Omoda/Jaecoo (Europe) and Chery (Europe) fill in everything automatically. Choose Custom to set the BFF endpoint, tenant code, country/channel IDs, MQTT host and certs by hand for any other region or brand."
         }
       },
       "reauth_password": {

--- a/custom_components/omoda9/translations/it.json
+++ b/custom_components/omoda9/translations/it.json
@@ -118,15 +118,22 @@
         "title": "Accedi con password",
         "description": "Inserisci e-mail, password e PIN del veicolo — nessun codice OTP. VIN e ID account rilevati in automatico. La password serve solo per accedere e non viene salvata.{reason}",
         "data": {
+          "preset": "Preset marchio / regione",
           "email": "E-mail account",
           "pin": "PIN comandi veicolo",
           "password": "Password account",
+          "language": "Lingua (e-mail / SMS OTP)",
           "bff": "Endpoint BFF (regione)",
+          "tenant_code": "Tenant code (avanzato)",
+          "country_id": "Country ID (avanzato)",
           "tsp_host": "Host console TSP (regione)",
           "car_mqtt_host": "Host broker MQTT del veicolo (regione)",
           "car_mqtt_port": "Porta broker MQTT del veicolo (regione)",
           "channel_id": "Channel ID (regione)",
           "certs_src": "Cartella coi certificati mutual-TLS da importare (opzionale)"
+        },
+        "data_description": {
+          "preset": "Omoda/Jaecoo (Europa) e Chery (Europa) compilano tutto da soli. Scegli «Custom» per impostare a mano BFF, tenant code, country/channel ID, broker MQTT e certificati per qualsiasi altra regione o marchio."
         }
       },
       "reauth_password": {

--- a/tests/test_traduzioni_complete.py
+++ b/tests/test_traduzioni_complete.py
@@ -57,3 +57,45 @@ def test_ogni_lingua_ha_le_chiavi_di_strings(nome):
         f"{nome} ha {len(in_piu)} chiavi che strings.json non dichiara: o sono rimaste da "
         f"una rimozione, o vanno aggiunte anche lì: {in_piu[:12]}"
     )
+
+
+# --------------------------------------------------------------------------------------
+# Il test sopra confronta i FILE fra loro. Non basta, e il 2026-09-05 si e' visto perche':
+# `_region_fields()` disegnava dieci campi in tutti e tre gli step di login, ma
+# `strings.json` ne dichiarava solo sei sotto `login_password`. Quattro campi comparivano
+# nel form SENZA etichetta, in tutte le lingue insieme -- quindi i tre file concordavano,
+# il test passava, e il difetto era visibile solo aprendo quella schermata.
+#
+# Non era colpa di nessuna delle due pull request: #16 scrisse `login_password` quando
+# `_region_fields()` non aveva ancora `preset`/`tenant_code`/`country_id`, e #19 aggiunse
+# quelle chiavi ai due step che sul suo ramo esistevano. Il difetto e' nato dall'incontro.
+# Un guardiano che confronta i file fra loro non puo' vedere una cosa del genere: deve
+# confrontarli con quello che il form DISEGNA.
+# --------------------------------------------------------------------------------------
+
+STEP_CON_CAMPI_DI_REGIONE = ("login_email", "login_phone", "login_password")
+
+
+def _campi_di_regione() -> set[str]:
+    """Le chiavi che `_region_fields()` mette davvero nel form, chieste al codice."""
+    from custom_components.omoda9.config_flow import Omoda9ConfigFlow
+
+    # `_region_fields` non tocca `self`: si puo' chiamare senza costruire il flow.
+    return {str(marcatore) for marcatore in Omoda9ConfigFlow._region_fields(None)}
+
+
+@pytest.mark.parametrize("step", STEP_CON_CAMPI_DI_REGIONE)
+def test_ogni_campo_disegnato_ha_una_etichetta(step):
+    """Ogni campo che il form mostra deve avere un'etichetta in `strings.json`."""
+    import json
+
+    strings = json.loads(FILES["strings.json"].read_text(encoding="utf-8"))
+    dichiarati = set(strings["config"]["step"][step].get("data", {}))
+
+    senza_etichetta = sorted(_campi_di_regione() - dichiarati)
+    assert not senza_etichetta, (
+        f"lo step `{step}` disegna {len(senza_etichetta)} campi che strings.json non "
+        f"nomina: {senza_etichetta}. Chi apre quella schermata li vede senza etichetta, "
+        f"in OGNI lingua -- e il confronto fra i file non se ne accorge, perche' mancano "
+        f"a tutti allo stesso modo."
+    )


### PR DESCRIPTION
A defect that landed on `master` today, found while comparing key sets for #50.

### What is wrong

`_region_fields()` returns ten fields, and all three login steps spread it into their
schema (`config_flow.py:479`, `:498`, `:541`). But `strings.json` declared only six of
them under `login_password`:

```
login_email      preset, language, tenant_code, country_id  present
login_phone      preset, language, tenant_code, country_id  present
login_password   all four MISSING
```

So the "Sign in with password" form draws four fields with no label, **in every language
at once**. Not a translation problem: an English user sees it too.

### Nobody wrote a bad diff

#16 wrote the `login_password` block when `_region_fields()` did not yet have `preset`,
`tenant_code` or `country_id`. #19 added those keys to the two steps that existed on its
branch, and `login_password` was not one of them. The defect exists in neither diff. It
was created by the two landing together, a few hours apart, which is why review could not
have caught it.

### The guard could not see it either, and that is the more interesting half

`test_traduzioni_complete.py` compares `strings.json`, `en.json` and `it.json` against
each other. All three were missing the same four keys, so the sets agreed and the test
passed: 653 green over a broken form. It verifies that no file was forgotten, not that
every field the form draws has a name.

This adds the missing half: ask `_region_fields()` what it actually renders, and require a
label for it in each login step.

**Verified the way a new test should be.** The real defect was put back into all three
files at once:

```
old test (file parity)  : 2 passed     <- the problem
new test (form coverage): 1 failed
  AssertionError: lo step `login_password` disegna 4 campi che strings.json non nomina:
  ['country_id', 'language', 'preset', 'tenant_code']
```

### Scope

The four values are copied from `login_email`, where the same fields are already
described. Nothing new was written, nothing needs translating. No version bump and no
changelog entry: the password login is itself unreleased, so this corrects a feature on
its way out rather than something a user has seen. 656 tests pass.

Related: this is the first concrete case for the wider question of how translations are
managed here, which #50 raised by adding a fourth language that the same guard does not
look at either.
