### PR TITLE
docs: the three authorities exist now, so stop calling them proposals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,12 +24,12 @@ vehicle turns out to accept.
 Where the truth lives, in order of authority:
 
 1. `docs/design/domain-model.md` — what the integration talks about. The code
-   implements it; it is not a description of the code. *(Proposed in #6.)*
+   implements it; it is not a description of the code.
 2. `docs/design/architecture.md` — where things live and which way dependencies
-   point. *(Proposed in #6.)*
+   point.
 3. `tests/` — what is actually guaranteed. `tests/test_entity_count.py` already
    enforces that no refactor quietly costs a user an entity;
-   `tests/test_architecture.py` enforces the layering *(proposed in #6)*.
+   `tests/test_architecture.py` enforces the layering.
 
 If your change contradicts one of these, the document wins, or the document
 changes in the same pull request. Never leave them disagreeing in silence.


### PR DESCRIPTION
#6 merged, so `docs/design/domain-model.md`, `docs/design/architecture.md` and `tests/test_architecture.py` are in the tree: two documents and four tests that run in the suite. AGENTS.md still marked all three "proposed in #6".

Small, but the marker mattered more than it looks: a rule book whose authorities are labelled as not yet existing is one a reader can reasonably skip, and that was the state of this file for eighteen days.