### PR TITLE
ci: fail a pull request that does not say what it finishes

### DIFF
--- a/.github/workflows/issue-link-guard.yml
+++ b/.github/workflows/issue-link-guard.yml
@@ -1,0 +1,60 @@
+name: Issue link guard
+
+# Every pull request that touches the integration says what it closes. The rule is in
+# AGENTS.md ("Put `Closes #12` in the body"), the template already has the line, and until
+# now nothing noticed when the line was left empty: eleven merges on 5-6 September, two
+# carried it. See #60 for the measurement.
+#
+# The point is not bookkeeping. Without the link, the issue outlives the fix and somebody
+# reopens the conversation months later, or worse, an issue somebody is waiting on stays
+# open after the thing they asked for has shipped.
+#
+# This file is in English, like `version-guard.yml` and for the same reason: the message
+# below is read by whoever trips over it, and not all of us read Italian.
+#
+# It runs on EVERY pull request, not only on the ones touching `custom_components/`.
+# Scoping it to code was tried on paper first and caught one of the five that prompted it:
+# the other four were documentation and a changelog, and two of those had more reason to
+# start as an issue than the code one did. With the `No issue:` escape costing a single
+# written line, there is no case for a narrower net.
+#
+# What it does NOT do: check that the issue exists, that it is open, or that it is the
+# right one. Those need judgement. This is a grep, and it is deliberately one.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  link:
+    runs-on: ubuntu-latest
+    steps:
+      - name: The body says what this finishes, or why it finishes nothing
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          # Three accepted forms. The third is not a loophole, it is the reason the other
+          # two stay honest: a defect found while doing something else does not always
+          # deserve an issue opened in front of it, and a check with no way out gets
+          # worked around instead of followed. What it costs is one written sentence.
+          if printf '%s' "$BODY" | grep -qiE '(clos(e|es|ed)|fix(e|es|ed)?|resolv(e|es|ed))[[:space:]]+#[0-9]+'; then
+            echo "Declares an issue it closes."
+            exit 0
+          fi
+          if printf '%s' "$BODY" | grep -qiE 'relates[[:space:]]+to[[:space:]]+#[0-9]+'; then
+            echo "Declares an issue it moves along."
+            exit 0
+          fi
+          # `No issue:` must be followed by an actual reason, not left bare.
+          if printf '%s' "$BODY" | grep -qiE 'no[[:space:]]+issue:[[:space:]]*[^[:space:]]+'; then
+            echo "Declares deliberately no issue, with a reason."
+            exit 0
+          fi
+
+          echo "::error::This pull request touches custom_components/ and its body does not say what it finishes. Add ONE of these lines: 'Closes #<n>' if it finishes an issue; 'Relates to #<n>' if it moves one along, saying in the body what is left; or 'No issue: <reason>' if there deliberately is not one, with the reason written out. The last form is not a formality to be filled with 'none' - it is what stops the other two from being skipped. The rule is in AGENTS.md, and #60 has the measurement that made this a check rather than a request." >&2
+          exit 1


### PR DESCRIPTION
Closes #60.

`AGENTS.md` asks every pull request to say what it closes, the template already carries the
line, and nothing noticed when it was left empty. The measurement is in #60: eleven merges on
5 and 6 September, two carried it.

### What it accepts

| form | meaning |
|---|---|
| `Closes #<n>` / `Fixes #<n>` / `Resolves #<n>` | it finishes an issue |
| `Relates to #<n>` | it moves one along; the body says what is left |
| `No issue: <reason>` | deliberately none, and the reason is written |

**The third one is why the other two stay honest.** A defect found while doing something else
does not always deserve an issue opened in front of it, and a check with no way out gets worked
around rather than followed. What it must cost is one written sentence. A bare `No issue:`
with nothing after it fails.

### Verified before pushing, not after

Ten cases run against the actual grep, including the one that decides whether this is worth
having:

```
should PASS
  Closes #13                          PASS (closes)
  Fixes #5                            PASS (closes)
  closes #7          (lowercase)      PASS (closes)
  Resolves #99                        PASS (closes)
  Relates to #10                      PASS (relates)
  No issue: found while porting       PASS (no issue + reason)

should FAIL
  the template's own empty "Closes #" FAIL
  no mention at all                   FAIL
  "No issue:" left bare               FAIL
  prose "this closes the discussion"  FAIL
```

The first of the failing four is the important one: that is the exact state #55, #56, #57, #58
and #59 were in.

### It runs on every pull request, not only on code

Scoping it to `custom_components/**` was written first and then measured against the five pull
requests that prompted it: it would have caught one. The other four were documentation and a
changelog, and two of those had more reason to begin as an issue than the code one did. With
the escape costing a single line there is no case for a narrower net.

### What it does not do

Check that the issue exists, that it is open, or that it is the right one. Those need
judgement; this is a grep and is deliberately one.

Not proposed here: opening issues retroactively for the eleven merged pull requests. That
produces a tidy trail describing a discussion that never happened.

The changelog rule has the same hole and is worth the same treatment, but separately: that one
has to decide what counts as a user-visible change, which is a judgement rather than a grep.
